### PR TITLE
Label images postsubmit if images are promoted to 'openshift' 

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,31 +168,13 @@ func generateJobs(
 	presubmits := map[string][]prowconfig.Presubmit{}
 	postsubmits := map[string][]prowconfig.Postsubmit{}
 
-	imagesTest := false
-
 	for _, element := range configSpec.Tests {
-		// Check if config file has "images" test defined to avoid name clash
-		// (we generate the additional `--target=[images]` jobs name with `images`
-		// as an identifier, but a user can have `images` test defined in his
-		// config file which would result in a clash)
-		if element.As == "images" {
-			imagesTest = true
-		}
 		test := testDescription{Name: element.As, Target: element.As}
 		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(test, org, repo, branch))
 	}
 
 	if len(configSpec.Images) > 0 {
-		var test testDescription
-		if imagesTest {
-			log.Print(
-				"WARNING: input config file has 'images' test defined\n" +
-					"This may get confused with built-in '[images]' target. Consider renaming this test.\n",
-			)
-			test = testDescription{Name: "[images]", Target: "[images]"}
-		} else {
-			test = testDescription{Name: "images", Target: "[images]"}
-		}
+		test := testDescription{Name: "images", Target: "[images]"}
 
 		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(test, org, repo, branch))
 

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -298,34 +298,6 @@ func TestGenerateJobs(t *testing.T) {
 				},
 			},
 		}, {
-			id: "test called 'images' and nonemtpy Images",
-			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{
-					{As: "images"},
-				},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
-			},
-			org:    "organization",
-			repo:   "repository",
-			branch: "branch",
-			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-images"},
-						{Name: "pull-ci-organization-repository-branch-[images]"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name: "branch-ci-organization-repository-branch-[images]",
-						},
-					},
-				},
-			},
-		}, {
 			id: "Promotion.Namespace is 'openshift'",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests: []ciop.TestStepConfiguration{},

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -240,7 +240,7 @@ func TestGenerateJobs(t *testing.T) {
 		expected            *prowconfig.JobConfig
 	}{
 		{
-			id: "two tests and empty Images",
+			id: "two tests and empty Images so only two test presubmits are generated",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests: []ciop.TestStepConfiguration{{As: "derTest"}, {As: "leTest"}},
 			},
@@ -255,7 +255,7 @@ func TestGenerateJobs(t *testing.T) {
 				Postsubmits: map[string][]prowconfig.Postsubmit{},
 			},
 		}, {
-			id: "two tests and nonempty Images",
+			id: "two tests and nonempty Images so two test presubmits and images pre/postsubmits are generated ",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:  []ciop.TestStepConfiguration{{As: "derTest"}, {As: "leTest"}},
 				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
@@ -274,7 +274,7 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 			},
 		}, {
-			id: "Promotion.Namespace is 'openshift'",
+			id: "Promotion.Namespace is 'openshift' so artifact label is added",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:                  []ciop.TestStepConfiguration{},
 				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
@@ -293,7 +293,7 @@ func TestGenerateJobs(t *testing.T) {
 				}}},
 			},
 		}, {
-			id: "Promotion.Namespace is not 'openshift'",
+			id: "Promotion.Namespace is not 'openshift' so no artifact label is added",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:                  []ciop.TestStepConfiguration{},
 				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
@@ -311,7 +311,7 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 			},
 		}, {
-			id: "tag_specification.Namespace is 'openshift' and no Promotion",
+			id: "no Promotion but tag_specification.Namespace is 'openshift' so artifact label is added",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:  []ciop.TestStepConfiguration{},
 				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
@@ -332,7 +332,7 @@ func TestGenerateJobs(t *testing.T) {
 				}}},
 			},
 		}, {
-			id: "tag_specification.Namespace is not 'openshift' and no Promotion",
+			id: "tag_specification.Namespace is not 'openshift' and no Promotion so artifact label is not added",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:  []ciop.TestStepConfiguration{},
 				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
@@ -352,7 +352,7 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 			},
 		}, {
-			id: "tag_specification.Namespace is 'openshift' and Promotion.Namespace is 'ci'",
+			id: "tag_specification.Namespace is 'openshift' and Promotion.Namespace is 'ci' so artifact label is not added",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:  []ciop.TestStepConfiguration{},
 				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
@@ -373,7 +373,7 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 			},
 		}, {
-			id: "tag_specification.Namespace is 'ci' and Promotion.Namespace is 'openshift'",
+			id: "tag_specification.Namespace is 'ci' and Promotion.Namespace is 'openshift' so artifact label is added",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:  []ciop.TestStepConfiguration{},
 				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -37,26 +37,22 @@ func TestGeneratePodSpec(t *testing.T) {
 
 			expected: &kubeapi.PodSpec{
 				ServiceAccountName: "ci-operator",
-				Containers: []kubeapi.Container{
-					{
-						Image:   "ci-operator:latest",
-						Command: []string{"ci-operator"},
-						Args:    []string{"--artifact-dir=$(ARTIFACTS)", "--target=target"},
-						Env: []kubeapi.EnvVar{
-							{
-								Name: "CONFIG_SPEC",
-								ValueFrom: &kubeapi.EnvVarSource{
-									ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-										LocalObjectReference: kubeapi.LocalObjectReference{
-											Name: "ci-operator-organization-repo",
-										},
-										Key: "branch.json",
-									},
+				Containers: []kubeapi.Container{{
+					Image:   "ci-operator:latest",
+					Command: []string{"ci-operator"},
+					Args:    []string{"--artifact-dir=$(ARTIFACTS)", "--target=target"},
+					Env: []kubeapi.EnvVar{{
+						Name: "CONFIG_SPEC",
+						ValueFrom: &kubeapi.EnvVarSource{
+							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+								LocalObjectReference: kubeapi.LocalObjectReference{
+									Name: "ci-operator-organization-repo",
 								},
+								Key: "branch.json",
 							},
 						},
-					},
-				},
+					}},
+				}},
 			},
 		},
 		{
@@ -68,26 +64,22 @@ func TestGeneratePodSpec(t *testing.T) {
 
 			expected: &kubeapi.PodSpec{
 				ServiceAccountName: "ci-operator",
-				Containers: []kubeapi.Container{
-					{
-						Image:   "ci-operator:latest",
-						Command: []string{"ci-operator"},
-						Args:    []string{"--artifact-dir=$(ARTIFACTS)", "--target=target", "--promote", "something"},
-						Env: []kubeapi.EnvVar{
-							{
-								Name: "CONFIG_SPEC",
-								ValueFrom: &kubeapi.EnvVarSource{
-									ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-										LocalObjectReference: kubeapi.LocalObjectReference{
-											Name: "ci-operator-organization-repo",
-										},
-										Key: "branch.json",
-									},
+				Containers: []kubeapi.Container{{
+					Image:   "ci-operator:latest",
+					Command: []string{"ci-operator"},
+					Args:    []string{"--artifact-dir=$(ARTIFACTS)", "--target=target", "--promote", "something"},
+					Env: []kubeapi.EnvVar{{
+						Name: "CONFIG_SPEC",
+						ValueFrom: &kubeapi.EnvVarSource{
+							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+								LocalObjectReference: kubeapi.LocalObjectReference{
+									Name: "ci-operator-organization-repo",
 								},
+								Key: "branch.json",
 							},
 						},
-					},
-				},
+					}},
+				}},
 			},
 		},
 	}
@@ -250,237 +242,157 @@ func TestGenerateJobs(t *testing.T) {
 		{
 			id: "two tests and empty Images",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{
-					{As: "derTest"},
-					{As: "leTest"},
-				},
+				Tests: []ciop.TestStepConfiguration{{As: "derTest"}, {As: "leTest"}},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-derTest"},
-						{Name: "pull-ci-organization-repository-branch-leTest"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-derTest"},
+					{Name: "pull-ci-organization-repository-branch-leTest"},
+				}},
 				Postsubmits: map[string][]prowconfig.Postsubmit{},
 			},
 		}, {
 			id: "two tests and nonempty Images",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{
-					{As: "derTest"},
-					{As: "leTest"},
-				},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
+				Tests:  []ciop.TestStepConfiguration{{As: "derTest"}, {As: "leTest"}},
+				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-derTest"},
-						{Name: "pull-ci-organization-repository-branch-leTest"},
-						{Name: "pull-ci-organization-repository-branch-images"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name: "branch-ci-organization-repository-branch-images",
-						},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-derTest"},
+					{Name: "pull-ci-organization-repository-branch-leTest"},
+					{Name: "pull-ci-organization-repository-branch-images"},
+				}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "branch-ci-organization-repository-branch-images"},
+				}},
 			},
 		}, {
 			id: "Promotion.Namespace is 'openshift'",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
-				PromotionConfiguration: &ciop.PromotionConfiguration{
-					Namespace: "openshift",
-				},
+				Tests:                  []ciop.TestStepConfiguration{},
+				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
+				PromotionConfiguration: &ciop.PromotionConfiguration{Namespace: "openshift"},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-images"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name:   "branch-ci-organization-repository-branch-images",
-							Labels: map[string]string{"artifacts": "images"},
-						},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-images"},
+				}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
+					Name:   "branch-ci-organization-repository-branch-images",
+					Labels: map[string]string{"artifacts": "images"},
+				}}},
 			},
 		}, {
 			id: "Promotion.Namespace is not 'openshift'",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
-				PromotionConfiguration: &ciop.PromotionConfiguration{
-					Namespace: "ci",
-				},
+				Tests:                  []ciop.TestStepConfiguration{},
+				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
+				PromotionConfiguration: &ciop.PromotionConfiguration{Namespace: "ci"},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-images"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name: "branch-ci-organization-repository-branch-images",
-						},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-images"},
+				}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "branch-ci-organization-repository-branch-images"},
+				}},
 			},
 		}, {
 			id: "tag_specification.Namespace is 'openshift' and no Promotion",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
+				Tests:  []ciop.TestStepConfiguration{},
+				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 				InputConfiguration: ciop.InputConfiguration{
-					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{
-						Namespace: "openshift",
-					},
+					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{Namespace: "openshift"},
 				},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-images"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name:   "branch-ci-organization-repository-branch-images",
-							Labels: map[string]string{"artifacts": "images"},
-						},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-images"},
+				}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
+					Name:   "branch-ci-organization-repository-branch-images",
+					Labels: map[string]string{"artifacts": "images"},
+				}}},
 			},
 		}, {
 			id: "tag_specification.Namespace is not 'openshift' and no Promotion",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
+				Tests:  []ciop.TestStepConfiguration{},
+				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 				InputConfiguration: ciop.InputConfiguration{
-					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{
-						Namespace: "ci",
-					},
+					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{Namespace: "ci"},
 				},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-images"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name: "branch-ci-organization-repository-branch-images",
-						},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-images"},
+				}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "branch-ci-organization-repository-branch-images"},
+				}},
 			},
 		}, {
 			id: "tag_specification.Namespace is 'openshift' and Promotion.Namespace is 'ci'",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
+				Tests:  []ciop.TestStepConfiguration{},
+				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 				InputConfiguration: ciop.InputConfiguration{
-					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{
-						Namespace: "openshift",
-					},
+					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{Namespace: "openshift"},
 				},
-				PromotionConfiguration: &ciop.PromotionConfiguration{
-					Namespace: "ci",
-				},
+				PromotionConfiguration: &ciop.PromotionConfiguration{Namespace: "ci"},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-images"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name: "branch-ci-organization-repository-branch-images",
-						},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-images"},
+				}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "branch-ci-organization-repository-branch-images"},
+				}},
 			},
 		}, {
 			id: "tag_specification.Namespace is 'ci' and Promotion.Namespace is 'openshift'",
 			config: &ciop.ReleaseBuildConfiguration{
-				Tests: []ciop.TestStepConfiguration{},
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{},
-				},
+				Tests:  []ciop.TestStepConfiguration{},
+				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 				InputConfiguration: ciop.InputConfiguration{
-					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{
-						Namespace: "ci",
-					},
+					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{Namespace: "ci"},
 				},
-				PromotionConfiguration: &ciop.PromotionConfiguration{
-					Namespace: "openshift",
-				},
+				PromotionConfiguration: &ciop.PromotionConfiguration{Namespace: "openshift"},
 			},
 			org:    "organization",
 			repo:   "repository",
 			branch: "branch",
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "pull-ci-organization-repository-branch-images"},
-					},
-				},
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{
-							Name:   "branch-ci-organization-repository-branch-images",
-							Labels: map[string]string{"artifacts": "images"},
-						},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "pull-ci-organization-repository-branch-images"},
+				}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
+					Name:   "branch-ci-organization-repository-branch-images",
+					Labels: map[string]string{"artifacts": "images"},
+				}}},
 			},
 		},
 	}
@@ -563,146 +475,108 @@ func TestMergeJobConfig(t *testing.T) {
 		{
 			destination: &prowconfig.JobConfig{},
 			source: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "source-job", Context: "ci/prow/source"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+				}},
 			},
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "source-job", Context: "ci/prow/source"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+				}},
 			},
 		}, {
 			destination: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "another-job", Context: "ci/prow/another"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "another-job", Context: "ci/prow/another"},
+				}},
 			},
 			source: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "source-job", Context: "ci/prow/source"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+				}},
 			},
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "source-job", Context: "ci/prow/source"},
-						{Name: "another-job", Context: "ci/prow/another"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+					{Name: "another-job", Context: "ci/prow/another"},
+				}},
 			},
 		}, {
 			destination: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "same-job", Context: "ci/prow/same"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "same-job", Context: "ci/prow/same"},
+				}},
 			},
 			source: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "same-job", Context: "ci/prow/different"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "same-job", Context: "ci/prow/different"},
+				}},
 			},
 			expected: &prowconfig.JobConfig{
-				Presubmits: map[string][]prowconfig.Presubmit{
-					"organization/repository": {
-						{Name: "same-job", Context: "ci/prow/different"},
-					},
-				},
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "same-job", Context: "ci/prow/different"},
+				}},
 			},
 		}, {
 			destination: &prowconfig.JobConfig{},
 			source: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "source-job", Agent: "ci/prow/source"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+				}},
 			},
 			expected: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "source-job", Agent: "ci/prow/source"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+				}},
 			},
 		}, {
 			destination: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "another-job", Agent: "ci/prow/another"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "another-job", Agent: "ci/prow/another"},
+				}},
 			},
 			source: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "source-job", Agent: "ci/prow/source"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+				}},
 			},
 			expected: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "source-job", Agent: "ci/prow/source"},
-						{Name: "another-job", Agent: "ci/prow/another"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+					{Name: "another-job", Agent: "ci/prow/another"},
+				}},
 			},
 		}, {
 			destination: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "same-job", Agent: "ci/prow/same"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
 			},
 			source: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "same-job", Agent: "ci/prow/different"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/different"},
+				}},
 			},
 			expected: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "same-job", Agent: "ci/prow/different"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/different"},
+				}},
 			},
 		}, {
 			destination: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "same-job", Agent: "ci/prow/same"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
 			},
 			source: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "same-job", Agent: "ci/prow/same"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
 			},
 			expected: &prowconfig.JobConfig{
-				Postsubmits: map[string][]prowconfig.Postsubmit{
-					"organization/repository": {
-						{Name: "same-job", Agent: "ci/prow/same"},
-					},
-				},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
If the images built & promoted by the `--target=[images]` postsubmit are
promoted into the `openshift` namespace, the postsubmit job should have
the 'artifacts: images' label.