### PR TITLE
Document what do we generate on what input

### DIFF
--- a/GENERATOR.md
+++ b/GENERATOR.md
@@ -1,0 +1,68 @@
+# Generated Prow jobs
+
+## Presubmits
+
+### Tests
+
+For each
+[test](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#tests)
+specified in the configuration file, generate one presubmit running ci-operator
+to build this test target.
+
+```yaml
+  - name: pull-ci-ORG-REPO-BRANCH-TEST
+    branches:
+    - BRANCH
+    context: ci/prow/TEST
+    rerun_command: /test TEST
+    spec: <pod that runs `ci-operator --target=TEST`>
+    trigger: ((?m)^/test( all| TEST),?(\\s+|$))
+    ...
+```
+
+### Images
+
+If the configuration file does have a non-empty
+[images](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#images)
+array, generate a presubmit running ci-operator to build the `[images]` target.
+
+
+```yaml
+  - name: pull-ci-ORG-REPO-BRANCH-images
+    branches:
+    - BRANCH
+    context: ci/prow/images
+    rerun_command: /test images
+    spec: <pod that runs `ci-operator --target=[images]`>
+    trigger: ((?m)^/test( all| images),?(\\s+|$))
+    ...
+```
+
+## Postsubmits
+
+### Images
+
+If the configuration file does have a non-empty
+[images](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#images)
+array, generate a postsubmit running ci-operator to built the `[images]`
+target. The postsubmit also uses the `--promote` option of ci-operator to
+promote the component images built by this postsubmit.
+
+```yaml
+  - name: branch-ci-ORG-REPO-BRANCH-images
+    spec: <pod that runs `ci-operator --target=[images] --promote>
+    ...
+```
+
+If the configuration file specifies a promotion namespace, either in
+[promotion.namespace](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#promotionnamespace)
+or in
+[tag_specification.namespace](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#tag_specificationnamespace),
+and this namespace is called `openshift`, this postsubmit job will also have `artifacts: images` label:
+
+```yaml
+  - name: branch-ci-ORG-REPO-BRANCH-images
+    labels:
+      artifacts: images
+    ...
+```

--- a/README.md
+++ b/README.md
@@ -79,48 +79,10 @@ $ ./ci-operator-prowgen --from-dir $GOPATH/src/github.com/openshift/release/ci-o
  --to-dir $GOPATH/src/github.com/openshift/release/ci-operator/jobs
 ```
 
-## What does the generator create
+## What does the generator create?
 
-The generator creates one presubmit job for each test specified in the
-ci-operator config file (in `tests` list):
+See [GENERATOR.md](GENERATOR.md).
 
-```yaml
-presubmits:
-  ORG/REPO:
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - master
-    context: ci/prow/TEST
-    decorate: true
-    name: pull-ci-ORG-REPO-BRANCH-TEST
-    rerun_command: /test TEST
-    skip_cloning: true
-    spec:
-      containers:
-      - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --target=TEST
-        command:
-        - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: BRANCH.json
-              name: ci-operator-ORG-REPO
-        image: ci-operator:latest
-        name: ""
-        resources: {}
-      serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| TEST),?(\\s+|$))
-```
-
-Also, if the configuration file has a non-empty `images` list, one additional
-presubmit and postsubmit job is generated with `--target=[images]` option passed
-to `ci-operator` to attempt to build the component images. This postsubmit job
-also uses the `--promote` option to promote the component images built in this
-way.
 
 ## Develop
 


### PR DESCRIPTION
Now when we have generation logic that is not absolutely trivial (especially with https://github.com/openshift/ci-operator-prowgen/pull/7), we should better document what do we want to generate on what input.

/cc @stevekuznetsov @droslean @bbguimaraes 