### PR TITLE
Change the ci-operator config format to YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ component?
 
 **Answer:**
 1. Get a working copy of [openshift/release](https://github.com/openshift/release) (we’ll shorten path to it to `$RELEASE`)
-2. Create a [ci-operator configuration file](https://github.com/openshift/ci-operator/blob/master/ONBOARD.md#prepare-configuration-for-component-repo) under `$RELEASE/ci-operator/config`, following the `organization/component/branch.json` convention.
+2. Create a [ci-operator configuration file](https://github.com/openshift/ci-operator/blob/master/ONBOARD.md#prepare-configuration-for-component-repo) under `$RELEASE/ci-operator/config`, following the `organization/component/branch.yaml` convention.
 3. Run `ci-operator-prowgen --from-dir $RELEASE/ci-operator/config/<org>/<component> --to-dir $RELEASE/ci-operator/jobs`
 4. Review Prow job configuration files created in `$RELEASE/ci-operator/jobs/<org>/<component>` 
 5. Commit both ci-operator configuration file and Prow job configuration files and issue a PR to upstream.
@@ -44,12 +44,12 @@ you may run the following (`$REPO is a path to `openshift/release` working
 copy):
 
 ```
-$ ./ci-operator-prowgen --from-file $REPO/ci-operator/config/org/component/branch.json \
+$ ./ci-operator-prowgen --from-file $REPO/ci-operator/config/org/component/branch.yaml \
  --to-dir $REPO/ci-operator/jobs
 ```
 
 This extracts the `org` and `component` from the configuration file path, reads
-the `branch.json` file and generates new Prow job configuration files in the
+the `branch.yaml` file and generates new Prow job configuration files in the
 `(...)/ci-operator/jobs/` directory, creating the necessary directory structure
 and files if needed. If the target files already exist and contain Prow job
 configuration, newly generated jobs will be merged with the old ones (jobs are
@@ -58,7 +58,7 @@ matched by name).
 ### Generate Prow jobs for multiple ci-operator config files
 
 The generator may take a directory as an input. In this case, the generator
-walks the directory structure under the given directory, finds all JSON files
+walks the directory structure under the given directory, finds all YAML files
 there and generates jobs for all of them.
 
 You can generate jobs for a certain component, organization, or everything:

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -104,15 +104,15 @@ type testDescription struct {
 }
 
 // Generate a Presubmit job for the given parameters
-func generatePresubmitForTest(test testDescription, org, repo, branch, configFilename string) *prowconfig.Presubmit {
+func generatePresubmitForTest(test testDescription, repoInfo *configFilePathElements) *prowconfig.Presubmit {
 	return &prowconfig.Presubmit{
 		Agent:        "kubernetes",
 		AlwaysRun:    true,
-		Brancher:     prowconfig.Brancher{Branches: []string{branch}},
+		Brancher:     prowconfig.Brancher{Branches: []string{repoInfo.branch}},
 		Context:      fmt.Sprintf("ci/prow/%s", test.Name),
-		Name:         fmt.Sprintf("pull-ci-%s-%s-%s-%s", org, repo, branch, test.Name),
+		Name:         fmt.Sprintf("pull-ci-%s-%s-%s-%s", repoInfo.org, repoInfo.repo, repoInfo.branch, test.Name),
 		RerunCommand: fmt.Sprintf("/test %s", test.Name),
-		Spec:         generatePodSpec(org, repo, configFilename, test.Target),
+		Spec:         generatePodSpec(repoInfo.org, repoInfo.repo, repoInfo.configFilename, test.Target),
 		Trigger:      fmt.Sprintf(`((?m)^/test( all| %s),?(\\s+|$))`, test.Name),
 		UtilityConfig: prowconfig.UtilityConfig{
 			DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
@@ -122,12 +122,16 @@ func generatePresubmitForTest(test testDescription, org, repo, branch, configFil
 }
 
 // Generate a Presubmit job for the given parameters
-func generatePostsubmitForTest(test testDescription, org, repo, branch, configFilename string, labels map[string]string, additionalArgs ...string) *prowconfig.Postsubmit {
+func generatePostsubmitForTest(
+	test testDescription,
+	repoInfo *configFilePathElements,
+	labels map[string]string,
+	additionalArgs ...string) *prowconfig.Postsubmit {
 	return &prowconfig.Postsubmit{
 		Agent:    "kubernetes",
-		Brancher: prowconfig.Brancher{Branches: []string{branch}},
-		Name:     fmt.Sprintf("branch-ci-%s-%s-%s-%s", org, repo, branch, test.Name),
-		Spec:     generatePodSpec(org, repo, configFilename, test.Target, additionalArgs...),
+		Brancher: prowconfig.Brancher{Branches: []string{repoInfo.branch}},
+		Name:     fmt.Sprintf("branch-ci-%s-%s-%s-%s", repoInfo.org, repoInfo.repo, repoInfo.branch, test.Name),
+		Spec:     generatePodSpec(repoInfo.org, repoInfo.repo, repoInfo.configFilename, test.Target, additionalArgs...),
 		Labels:   labels,
 		UtilityConfig: prowconfig.UtilityConfig{
 			DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
@@ -157,23 +161,22 @@ func extractPromotionNamespace(configSpec *cioperatorapi.ReleaseBuildConfigurati
 //   presubmit and postsubmit that has `--target=[images]`. This postsubmit
 //   will additionally pass `--promote` to ci-operator
 func generateJobs(
-	configSpec *cioperatorapi.ReleaseBuildConfiguration,
-	org, repo, branch, configFilename string,
+	configSpec *cioperatorapi.ReleaseBuildConfiguration, repoInfo *configFilePathElements,
 ) *prowconfig.JobConfig {
 
-	orgrepo := fmt.Sprintf("%s/%s", org, repo)
+	orgrepo := fmt.Sprintf("%s/%s", repoInfo.org, repoInfo.repo)
 	presubmits := map[string][]prowconfig.Presubmit{}
 	postsubmits := map[string][]prowconfig.Postsubmit{}
 
 	for _, element := range configSpec.Tests {
 		test := testDescription{Name: element.As, Target: element.As}
-		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(test, org, repo, branch, configFilename))
+		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(test, repoInfo))
 	}
 
 	if len(configSpec.Images) > 0 {
 		test := testDescription{Name: "images", Target: "[images]"}
 
-		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(test, org, repo, branch, configFilename))
+		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(test, repoInfo))
 
 		// If the images are promoted to 'openshift' namespace, we may want to add
 		// 'artifacts: images' label to the [images] postsubmit.
@@ -181,7 +184,7 @@ func generateJobs(
 		if extractPromotionNamespace(configSpec) == "openshift" {
 			labels["artifacts"] = "images"
 		}
-		imagesPostsubmit := generatePostsubmitForTest(test, org, repo, branch, configFilename, labels, "--promote")
+		imagesPostsubmit := generatePostsubmitForTest(test, repoInfo, labels, "--promote")
 		postsubmits[orgrepo] = append(postsubmits[orgrepo], *imagesPostsubmit)
 	}
 
@@ -205,42 +208,50 @@ func readCiOperatorConfig(configFilePath string) (*cioperatorapi.ReleaseBuildCon
 	return configSpec, nil
 }
 
+// path to ci-operator configuration file encodes information about tested code
+// .../$ORGANIZATION/$REPOSITORY/$BRANCH.$EXT
+type configFilePathElements struct {
+	org            string
+	repo           string
+	branch         string
+	configFilename string
+}
+
 // We use the directory/file naming convention to encode useful information
 // about component repository information.
 // The convention for ci-operator config files in this repo:
 // ci-operator/config/ORGANIZATION/COMPONENT/BRANCH.yaml
-func extractRepoElementsFromPath(configFilePath string) (string, string, string, string, error) {
+func extractRepoElementsFromPath(configFilePath string) (*configFilePathElements, error) {
 	configSpecDir := filepath.Dir(configFilePath)
 	repo := filepath.Base(configSpecDir)
 	if repo == "." || repo == "/" {
-		return "", "", "", "", fmt.Errorf("Could not extract repo from '%s' (expected path like '.../ORG/REPO/BRANCH.yaml", configFilePath)
+		return nil, fmt.Errorf("Could not extract repo from '%s' (expected path like '.../ORG/REPO/BRANCH.yaml", configFilePath)
 	}
 
 	org := filepath.Base(filepath.Dir(configSpecDir))
 	if org == "." || org == "/" {
-		return "", "", "", "", fmt.Errorf("Could not extract org from '%s' (expected path like '.../ORG/REPO/BRANCH.yaml", configFilePath)
+		return nil, fmt.Errorf("Could not extract org from '%s' (expected path like '.../ORG/REPO/BRANCH.yaml", configFilePath)
 	}
 
 	fileName := filepath.Base(configFilePath)
-
 	branch := strings.TrimSuffix(fileName, filepath.Ext(configFilePath))
 
-	return org, repo, branch, fileName, nil
+	return &configFilePathElements{org, repo, branch, fileName}, nil
 }
 
-func generateProwJobsFromConfigFile(configFilePath string) (*prowconfig.JobConfig, string, string, error) {
+func generateProwJobsFromConfigFile(configFilePath string) (*prowconfig.JobConfig, *configFilePathElements, error) {
 	configSpec, err := readCiOperatorConfig(configFilePath)
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, err
 	}
 
-	org, repo, branch, configFilename, err := extractRepoElementsFromPath(configFilePath)
+	repoInfo, err := extractRepoElementsFromPath(configFilePath)
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, err
 	}
-	jobConfig := generateJobs(configSpec, org, repo, branch, configFilename)
+	jobConfig := generateJobs(configSpec, repoInfo)
 
-	return jobConfig, org, repo, nil
+	return jobConfig, repoInfo, nil
 }
 
 // Given a JobConfig and a target directory, write the Prow job configuration
@@ -279,13 +290,13 @@ func generateJobsFromDirectory(configDir, jobDir, jobFile string) error {
 			return err
 		}
 		if !info.IsDir() && filepath.Ext(path) == ".yaml" {
-			jobConfig, org, repo, err := generateProwJobsFromConfigFile(path)
+			jobConfig, repoInfo, err := generateProwJobsFromConfigFile(path)
 			if err != nil {
 				return err
 			}
 
 			if len(jobDir) > 0 {
-				if err = writeJobsIntoComponentDirectory(jobDir, org, repo, jobConfig); err != nil {
+				if err = writeJobsIntoComponentDirectory(jobDir, repoInfo.org, repoInfo.repo, jobConfig); err != nil {
 					return err
 				}
 			} else if len(jobFile) > 0 {
@@ -403,7 +414,7 @@ func main() {
 	}
 
 	if len(opt.fromFile) > 0 {
-		jobConfig, org, repo, err := generateProwJobsFromConfigFile(opt.fromFile)
+		jobConfig, repoInfo, err := generateProwJobsFromConfigFile(opt.fromFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to generate jobs from '%s' (%v)\n", opt.fromFile, err)
 			os.Exit(1)
@@ -414,7 +425,7 @@ func main() {
 				os.Exit(1)
 			}
 		} else { // from file to directory
-			if err := writeJobsIntoComponentDirectory(opt.toDir, org, repo, jobConfig); err != nil {
+			if err := writeJobsIntoComponentDirectory(opt.toDir, repoInfo.org, repoInfo.repo, jobConfig); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to write jobs to '%s' (%v)\n", opt.toDir, err)
 				os.Exit(1)
 			}

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -280,6 +280,11 @@ func writeJobsIntoComponentDirectory(jobDir, org, repo string, jobConfig *prowco
 	return nil
 }
 
+func isConfigFile(path string, info os.FileInfo) bool {
+	extension := filepath.Ext(path)
+	return !info.IsDir() && (extension == ".yaml" || extension == ".yml" || extension == ".json")
+}
+
 // Iterate over all ci-operator config files under a given path and generate a
 // Prow job configuration files for each one under a different path, mimicking
 // the directory structure.
@@ -289,7 +294,7 @@ func generateJobsFromDirectory(configDir, jobDir, jobFile string) error {
 			fmt.Fprintf(os.Stderr, "Error encontered while generating Prow job config: %v\n", err)
 			return err
 		}
-		if !info.IsDir() && filepath.Ext(path) == ".yaml" {
+		if isConfigFile(path, info) {
 			jobConfig, repoInfo, err := generateProwJobsFromConfigFile(path)
 			if err != nil {
 				return err


### PR DESCRIPTION
*this should be merged only after https://github.com/openshift/ci-operator/pull/121 is merged*

/hold

Parse ci-operator config files as YAML instead of JSON. Generated jobs do not change, except for the `ConfigMap` part, where we generate the filename to always  be a `.yaml`, so we won't  be able to generate jobs for `.json` files in the directory-walking mode. (I need to fix this) 