### PR TITLE
Generated postsubmits should have `branch` set

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -128,10 +128,11 @@ func generatePresubmitForTest(test testDescription, org, repo, branch string) *p
 // Generate a Presubmit job for the given parameters
 func generatePostsubmitForTest(test testDescription, org, repo, branch string, labels map[string]string, additionalArgs ...string) *prowconfig.Postsubmit {
 	return &prowconfig.Postsubmit{
-		Agent:  "kubernetes",
-		Name:   fmt.Sprintf("branch-ci-%s-%s-%s-%s", org, repo, branch, test.Name),
-		Spec:   generatePodSpec(org, repo, branch, test.Target, additionalArgs...),
-		Labels: labels,
+		Agent:    "kubernetes",
+		Brancher: prowconfig.Brancher{Branches: []string{branch}},
+		Name:     fmt.Sprintf("branch-ci-%s-%s-%s-%s", org, repo, branch, test.Name),
+		Spec:     generatePodSpec(org, repo, branch, test.Target, additionalArgs...),
+		Labels:   labels,
 		UtilityConfig: prowconfig.UtilityConfig{
 			DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
 			Decorate:         true,

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -138,7 +138,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 	}
 }
 
-func TestGeneratePostSumitForTest(t *testing.T) {
+func TestGeneratePostSubmitForTest(t *testing.T) {
 	tests := []struct {
 		name           string
 		target         string
@@ -160,8 +160,9 @@ func TestGeneratePostSumitForTest(t *testing.T) {
 			additionalArgs: []string{},
 
 			expected: &prowconfig.Postsubmit{
-				Agent: "kubernetes",
-				Name:  "branch-ci-organization-repository-branch-name",
+				Agent:    "kubernetes",
+				Name:     "branch-ci-organization-repository-branch-name",
+				Brancher: prowconfig.Brancher{Branches: []string{"branch"}},
 				UtilityConfig: prowconfig.UtilityConfig{
 					DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
 					Decorate:         true,
@@ -178,8 +179,9 @@ func TestGeneratePostSumitForTest(t *testing.T) {
 			additionalArgs: []string{"--promote", "additionalArg"},
 
 			expected: &prowconfig.Postsubmit{
-				Agent: "kubernetes",
-				Name:  "branch-ci-organization-repository-branch-name",
+				Agent:    "kubernetes",
+				Name:     "branch-ci-organization-repository-branch-name",
+				Brancher: prowconfig.Brancher{Branches: []string{"branch"}},
 				UtilityConfig: prowconfig.UtilityConfig{
 					DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
 					Decorate:         true,
@@ -196,9 +198,10 @@ func TestGeneratePostSumitForTest(t *testing.T) {
 			additionalArgs: []string{"--promote", "additionalArg"},
 
 			expected: &prowconfig.Postsubmit{
-				Agent:  "kubernetes",
-				Name:   "branch-ci-Organization-Repository-Branch-Name",
-				Labels: map[string]string{"artifacts": "images"},
+				Agent:    "kubernetes",
+				Name:     "branch-ci-Organization-Repository-Branch-Name",
+				Brancher: prowconfig.Brancher{Branches: []string{"Branch"}},
+				Labels:   map[string]string{"artifacts": "images"},
 				UtilityConfig: prowconfig.UtilityConfig{
 					DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
 					Decorate:         true,
@@ -426,6 +429,7 @@ func prune(jobConfig *prowconfig.JobConfig) {
 		for i := range jobConfig.Postsubmits[repo] {
 			jobConfig.Postsubmits[repo][i].Agent = ""
 			jobConfig.Postsubmits[repo][i].Spec = nil
+			jobConfig.Postsubmits[repo][i].Brancher = prowconfig.Brancher{}
 			jobConfig.Postsubmits[repo][i].UtilityConfig = prowconfig.UtilityConfig{}
 		}
 	}
@@ -645,6 +649,8 @@ func TestFromCIOperatorConfigToProwYaml(t *testing.T) {
 			prowExpectedYAML: []byte(`postsubmits:
   super/duper:
   - agent: kubernetes
+    branches:
+    - branch
     decorate: true
     labels:
       artifacts: images
@@ -746,6 +752,8 @@ presubmits:
 			prowOldYAML: []byte(`postsubmits:
   super/duper:
   - agent: kubernetes
+    branches:
+    - branch
     decorate: true
     name: branch-ci-super-duper-branch-do-not-overwrite
     skip_cloning: true
@@ -770,6 +778,8 @@ presubmits:
 			prowExpectedYAML: []byte(`postsubmits:
   super/duper:
   - agent: kubernetes
+    branches:
+    - branch
     decorate: true
     labels:
       artifacts: images
@@ -794,6 +804,8 @@ presubmits:
         resources: {}
       serviceAccountName: ci-operator
   - agent: kubernetes
+    branches:
+    - branch
     decorate: true
     name: branch-ci-super-duper-branch-do-not-overwrite
     skip_cloning: true


### PR DESCRIPTION
Currently, we generate postsubmits without any `branches:` set, which is clearly wrong, at least for the postsubmits that do `--promote`.

/cc @stevekuznetsov @bbguimaraes @droslean 