### PR TITLE
Fix triggering regexp

### DIFF
--- a/GENERATOR.md
+++ b/GENERATOR.md
@@ -16,7 +16,7 @@ to build this test target.
     context: ci/prow/TEST
     rerun_command: /test TEST
     spec: <pod that runs `ci-operator --target=TEST`>
-    trigger: ((?m)^/test( all| TEST),?(\\s+|$))
+    trigger: ((?m)^/test( all| TEST),?(\s+|$))
     ...
 ```
 
@@ -34,7 +34,7 @@ array, generate a presubmit running ci-operator to build the `[images]` target.
     context: ci/prow/images
     rerun_command: /test images
     spec: <pod that runs `ci-operator --target=[images]`>
-    trigger: ((?m)^/test( all| images),?(\\s+|$))
+    trigger: ((?m)^/test( all| images),?(\s+|$))
     ...
 ```
 

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -113,7 +113,7 @@ func generatePresubmitForTest(test testDescription, repoInfo *configFilePathElem
 		Name:         fmt.Sprintf("pull-ci-%s-%s-%s-%s", repoInfo.org, repoInfo.repo, repoInfo.branch, test.Name),
 		RerunCommand: fmt.Sprintf("/test %s", test.Name),
 		Spec:         generatePodSpec(repoInfo.org, repoInfo.repo, repoInfo.configFilename, test.Target),
-		Trigger:      fmt.Sprintf(`((?m)^/test( all| %s),?(\\s+|$))`, test.Name),
+		Trigger:      fmt.Sprintf(`((?m)^/test( all| %s),?(\s+|$))`, test.Name),
 		UtilityConfig: prowconfig.UtilityConfig{
 			DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
 			Decorate:         true,

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -115,7 +115,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 			Context:      "ci/prow/testname",
 			Name:         "pull-ci-org-repo-branch-testname",
 			RerunCommand: "/test testname",
-			Trigger:      `((?m)^/test( all| testname),?(\\s+|$))`,
+			Trigger:      `((?m)^/test( all| testname),?(\s+|$))`,
 			UtilityConfig: prowconfig.UtilityConfig{
 				DecorationConfig: &prowkube.DecorationConfig{SkipCloning: true},
 				Decorate:         true,
@@ -730,7 +730,7 @@ presubmits:
         name: ""
         resources: {}
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| unit),?(\\s+|$))
+    trigger: ((?m)^/test( all| unit),?(\s+|$))
   - agent: kubernetes
     always_run: true
     branches:
@@ -757,7 +757,7 @@ presubmits:
         name: ""
         resources: {}
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\\s+|$))
+    trigger: ((?m)^/test( all| images),?(\s+|$))
 `)}, {
 			id:        "One test and images, one existing job. Expect one presubmit, pre/post submit images jobs. Existing job should not be changed.",
 			org:       "super",
@@ -883,7 +883,7 @@ presubmits:
         name: ""
         resources: {}
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| unit),?(\\s+|$))
+    trigger: ((?m)^/test( all| unit),?(\s+|$))
   - agent: kubernetes
     always_run: true
     branches:
@@ -910,7 +910,7 @@ presubmits:
         name: ""
         resources: {}
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\\s+|$))
+    trigger: ((?m)^/test( all| images),?(\s+|$))
 `),
 		}, {
 			id:        "Input is YAML and it is correctly processed",
@@ -1042,7 +1042,7 @@ presubmits:
         name: ""
         resources: {}
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| unit),?(\\s+|$))
+    trigger: ((?m)^/test( all| unit),?(\s+|$))
   - agent: kubernetes
     always_run: true
     branches:
@@ -1069,7 +1069,7 @@ presubmits:
         name: ""
         resources: {}
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\\s+|$))
+    trigger: ((?m)^/test( all| images),?(\s+|$))
 `),
 		},
 	}


### PR DESCRIPTION
In plain YAML string literals, backlashes do not need to be escaped