### PR TITLE
Warn when generated job name is longer than 63 chars

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,7 @@
 required = [
 	"github.com/ghodss/yaml",
 	"github.com/openshift/ci-operator/pkg/api",
+	"github.com/sirupsen/logrus",
 	"k8s.io/test-infra/prow/config",
 	"k8s.io/test-infra/prow/kube",
 	"k8s.io/api/core/v1",

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -34,7 +34,7 @@ func WriteToFile(path string, jobConfig *prowconfig.JobConfig) error {
 		return fmt.Errorf("failed to marshal the job config (%v)", err)
 	}
 	if err := ioutil.WriteFile(path, jobConfigAsYaml, 0664); err != nil {
-		return fmt.Errorf("Failed to write job config to '%s' (%v)", path, err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Also, because this was a good opportunity, make all messages go through logging, using the `logrus` library.