### PR TITLE
Refactor generator to write at the directory level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ lint:
 format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )
 .PHONY: format
+
+integration:
+	test/integration/run.sh
+.PHONY: integration

--- a/cmd/determinize-prow-jobs/main.go
+++ b/cmd/determinize-prow-jobs/main.go
@@ -33,7 +33,7 @@ func determinizeJobs(prowJobConfigDir string) error {
 			return nil
 		}
 
-		if info.IsDir() && filepath.Dir(filepath.Dir(path)) == prowJobConfigDir {
+		if info.IsDir() && filepath.Clean(filepath.Dir(filepath.Dir(path))) == filepath.Clean(prowJobConfigDir) {
 			var jobConfig *prowconfig.JobConfig
 			if jobConfig, err = jc.ReadFromDir(path); err != nil {
 				return fmt.Errorf("failed to read Prow job config from '%s' (%v)", path, err)

--- a/cmd/determinize-prow-jobs/main.go
+++ b/cmd/determinize-prow-jobs/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 
 	prowconfig "k8s.io/test-infra/prow/config"
 
@@ -34,31 +33,21 @@ func determinizeJobs(prowJobConfigDir string) error {
 			return nil
 		}
 
-		if !info.IsDir() && filepath.Ext(path) == ".yaml" {
+		if info.IsDir() && filepath.Dir(filepath.Dir(path)) == prowJobConfigDir {
 			var jobConfig *prowconfig.JobConfig
-			if jobConfig, err = jc.ReadFromFile(path); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to read Prow job config from '%s' (%v)", path, err)
-				return nil
+			if jobConfig, err = jc.ReadFromDir(path); err != nil {
+				return fmt.Errorf("failed to read Prow job config from '%s' (%v)", path, err)
 			}
 
-			for repo := range jobConfig.Presubmits {
-				sort.Slice(jobConfig.Presubmits[repo], func(i, j int) bool {
-					return jobConfig.Presubmits[repo][i].Name < jobConfig.Presubmits[repo][j].Name
-				})
-			}
-			for repo := range jobConfig.Postsubmits {
-				sort.Slice(jobConfig.Postsubmits[repo], func(i, j int) bool {
-					return jobConfig.Postsubmits[repo][i].Name < jobConfig.Postsubmits[repo][j].Name
-				})
-			}
-			if err := jc.WriteToFile(path, jobConfig); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to write Prow job config to '%s' (%v)", path, err)
-				return nil
+			repo := filepath.Base(path)
+			org := filepath.Base(filepath.Dir(path))
+			if err := jc.WriteToDir(prowJobConfigDir, org, repo, jobConfig); err != nil {
+				return fmt.Errorf("failed to write Prow job config to '%s' (%v)", path, err)
 			}
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("Failed to determinize all Prow jobs")
+		return fmt.Errorf("failed to determinize all Prow jobs: %v", err)
 	}
 
 	return nil
@@ -80,7 +69,7 @@ func main() {
 
 		}
 	} else {
-		fmt.Fprintf(os.Stderr, "determinize tool needs the --prow-jobs-dir\n")
+		fmt.Fprintln(os.Stderr, "determinize tool needs the --prow-jobs-dir")
 		os.Exit(1)
 	}
 }

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -3,14 +3,74 @@ package jobconfig
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
 
 	"github.com/ghodss/yaml"
 
 	prowconfig "k8s.io/test-infra/prow/config"
 )
 
-// ReadFromFile reads Prow job config from a YAML file
-func ReadFromFile(path string) (*prowconfig.JobConfig, error) {
+// ReadFromDir reads Prow job config from a directory and merges into one config
+func ReadFromDir(dir string) (*prowconfig.JobConfig, error) {
+	jobConfig := &prowconfig.JobConfig{
+		Presubmits:  map[string][]prowconfig.Presubmit{},
+		Postsubmits: map[string][]prowconfig.Postsubmit{},
+	}
+	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to walk file/directory '%s'", path)
+			return nil
+		}
+
+		if !info.IsDir() && filepath.Ext(path) == ".yaml" {
+			var configPart *prowconfig.JobConfig
+			if configPart, err = readFromFile(path); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to read Prow job config from '%s' (%v)", path, err)
+				return nil
+			}
+
+			mergeConfigs(jobConfig, configPart)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to determinize all Prow jobs: %v", err)
+	}
+
+	return jobConfig, nil
+}
+
+// mergeConfigs merges job configuration from part into dest
+func mergeConfigs(dest, part *prowconfig.JobConfig) {
+	if part.Presubmits != nil {
+		if dest.Presubmits == nil {
+			dest.Presubmits = map[string][]prowconfig.Presubmit{}
+		}
+		for repo := range part.Presubmits {
+			if _, ok := dest.Presubmits[repo]; ok {
+				dest.Presubmits[repo] = append(dest.Presubmits[repo], part.Presubmits[repo]...)
+			} else {
+				dest.Presubmits[repo] = part.Presubmits[repo]
+			}
+		}
+	}
+	if part.Postsubmits != nil {
+		if dest.Postsubmits == nil {
+			dest.Postsubmits = map[string][]prowconfig.Postsubmit{}
+		}
+		for repo := range part.Postsubmits {
+			if _, ok := dest.Postsubmits[repo]; ok {
+				dest.Postsubmits[repo] = append(dest.Postsubmits[repo], part.Postsubmits[repo]...)
+			} else {
+				dest.Postsubmits[repo] = part.Postsubmits[repo]
+			}
+		}
+	}
+}
+
+// readFromFile reads Prow job config from a YAML file
+func readFromFile(path string) (*prowconfig.JobConfig, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Prow job config (%v)", err)
@@ -27,8 +87,126 @@ func ReadFromFile(path string) (*prowconfig.JobConfig, error) {
 	return jobConfig, nil
 }
 
-// WriteToFile writes Prow job config to a YAML file
-func WriteToFile(path string, jobConfig *prowconfig.JobConfig) error {
+// Given a JobConfig and a target directory, write the Prow job configuration
+// into files in that directory. Jobs are sharded by branch and by type. If
+// target files already exist and contain Prow job configuration, the jobs will
+// be merged.
+func WriteToDir(jobDir, org, repo string, jobConfig *prowconfig.JobConfig) error {
+	files := map[string]*prowconfig.JobConfig{}
+	key := fmt.Sprintf("%s/%s", org, repo)
+	for _, job := range jobConfig.Presubmits[key] {
+		file := fmt.Sprintf("%s-%s-%s-presubmits.yaml", org, repo, job.Branches[0])
+		if _, ok := files[file]; ok {
+			files[file].Presubmits[key] = append(files[file].Presubmits[key], job)
+		} else {
+			files[file] = &prowconfig.JobConfig{Presubmits: map[string][]prowconfig.Presubmit{
+				key: {job},
+			}}
+		}
+	}
+	for _, job := range jobConfig.Postsubmits[key] {
+		file := fmt.Sprintf("%s-%s-%s-postsubmits.yaml", org, repo, job.Branches[0])
+		if _, ok := files[file]; ok {
+			files[file].Postsubmits[key] = append(files[file].Postsubmits[key], job)
+		} else {
+			files[file] = &prowconfig.JobConfig{Postsubmits: map[string][]prowconfig.Postsubmit{
+				key: {job},
+			}}
+		}
+	}
+
+	jobDirForComponent := filepath.Join(jobDir, org, repo)
+	if err := os.MkdirAll(jobDirForComponent, os.ModePerm); err != nil {
+		return err
+	}
+	for file := range files {
+		if err := mergeJobsIntoFile(filepath.Join(jobDirForComponent, file), files[file]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Given a JobConfig and a file path, write YAML representation of the config
+// to the file path. If the file already contains some jobs, new ones will be
+// merged with the existing ones.
+func mergeJobsIntoFile(prowConfigPath string, jobConfig *prowconfig.JobConfig) error {
+	existingJobConfig, err := readFromFile(prowConfigPath)
+	if err != nil {
+		existingJobConfig = &prowconfig.JobConfig{}
+	}
+
+	mergeJobConfig(existingJobConfig, jobConfig)
+	for repo := range existingJobConfig.Presubmits {
+		sort.Slice(existingJobConfig.Presubmits[repo], func(i, j int) bool {
+			return existingJobConfig.Presubmits[repo][i].Name < existingJobConfig.Presubmits[repo][j].Name
+		})
+	}
+	for repo := range existingJobConfig.Postsubmits {
+		sort.Slice(existingJobConfig.Postsubmits[repo], func(i, j int) bool {
+			return existingJobConfig.Postsubmits[repo][i].Name < existingJobConfig.Postsubmits[repo][j].Name
+		})
+	}
+
+	return writeToFile(prowConfigPath, existingJobConfig)
+}
+
+// Given two JobConfig, merge jobs from the `source` one to to `destination`
+// one. Jobs are matched by name. All jobs from `source` will be present in
+// `destination` - if there were jobs with the same name in `destination`, they
+// will be overwritten. All jobs in `destination` that are not overwritten this
+// way stay untouched.
+func mergeJobConfig(destination, source *prowconfig.JobConfig) {
+	// We do the same thing for both Presubmits and Postsubmits
+	if source.Presubmits != nil {
+		if destination.Presubmits == nil {
+			destination.Presubmits = map[string][]prowconfig.Presubmit{}
+		}
+		for repo, jobs := range source.Presubmits {
+			oldPresubmits, _ := destination.Presubmits[repo]
+			destination.Presubmits[repo] = []prowconfig.Presubmit{}
+			newJobs := map[string]prowconfig.Presubmit{}
+			for _, job := range jobs {
+				newJobs[job.Name] = job
+			}
+			for _, newJob := range source.Presubmits[repo] {
+				destination.Presubmits[repo] = append(destination.Presubmits[repo], newJob)
+			}
+
+			for _, oldJob := range oldPresubmits {
+				if _, hasKey := newJobs[oldJob.Name]; !hasKey {
+					destination.Presubmits[repo] = append(destination.Presubmits[repo], oldJob)
+				}
+			}
+		}
+	}
+	if source.Postsubmits != nil {
+		if destination.Postsubmits == nil {
+			destination.Postsubmits = map[string][]prowconfig.Postsubmit{}
+		}
+		for repo, jobs := range source.Postsubmits {
+			oldPostsubmits, _ := destination.Postsubmits[repo]
+			destination.Postsubmits[repo] = []prowconfig.Postsubmit{}
+			newJobs := map[string]prowconfig.Postsubmit{}
+			for _, job := range jobs {
+				newJobs[job.Name] = job
+			}
+			for _, newJob := range source.Postsubmits[repo] {
+				destination.Postsubmits[repo] = append(destination.Postsubmits[repo], newJob)
+			}
+
+			for _, oldJob := range oldPostsubmits {
+				if _, hasKey := newJobs[oldJob.Name]; !hasKey {
+					destination.Postsubmits[repo] = append(destination.Postsubmits[repo], oldJob)
+				}
+			}
+		}
+	}
+}
+
+// writeToFile writes Prow job config to a YAML file
+func writeToFile(path string, jobConfig *prowconfig.JobConfig) error {
 	jobConfigAsYaml, err := yaml.Marshal(*jobConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal the job config (%v)", err)

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -95,7 +95,11 @@ func WriteToDir(jobDir, org, repo string, jobConfig *prowconfig.JobConfig) error
 	files := map[string]*prowconfig.JobConfig{}
 	key := fmt.Sprintf("%s/%s", org, repo)
 	for _, job := range jobConfig.Presubmits[key] {
-		file := fmt.Sprintf("%s-%s-%s-presubmits.yaml", org, repo, job.Branches[0])
+		branch := "master"
+		if len(job.Branches) > 0 {
+			branch = job.Branches[0]
+		}
+		file := fmt.Sprintf("%s-%s-%s-presubmits.yaml", org, repo, branch)
 		if _, ok := files[file]; ok {
 			files[file].Presubmits[key] = append(files[file].Presubmits[key], job)
 		} else {
@@ -105,7 +109,11 @@ func WriteToDir(jobDir, org, repo string, jobConfig *prowconfig.JobConfig) error
 		}
 	}
 	for _, job := range jobConfig.Postsubmits[key] {
-		file := fmt.Sprintf("%s-%s-%s-postsubmits.yaml", org, repo, job.Branches[0])
+		branch := "master"
+		if len(job.Branches) > 0 {
+			branch = job.Branches[0]
+		}
+		file := fmt.Sprintf("%s-%s-%s-postsubmits.yaml", org, repo, branch)
 		if _, ok := files[file]; ok {
 			files[file].Postsubmits[key] = append(files[file].Postsubmits[key], job)
 		} else {

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -1,0 +1,194 @@
+package jobconfig
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/diff"
+	prowconfig "k8s.io/test-infra/prow/config"
+)
+
+func TestMergeConfigs(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		dest     *prowconfig.JobConfig
+		part     *prowconfig.JobConfig
+		expected *prowconfig.JobConfig
+	}{
+		{
+			name:     "empty dest and empty part leads to empty result",
+			dest:     &prowconfig.JobConfig{},
+			part:     &prowconfig.JobConfig{},
+			expected: &prowconfig.JobConfig{},
+		},
+		{
+			name: "empty dest leads to copy of part",
+			dest: &prowconfig.JobConfig{},
+			part: &prowconfig.JobConfig{
+				Presubmits:  map[string][]prowconfig.Presubmit{"super/duper": {{Name: "test"}}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"super/duper": {{Name: "post-test"}}},
+			},
+			expected: &prowconfig.JobConfig{
+				Presubmits:  map[string][]prowconfig.Presubmit{"super/duper": {{Name: "test"}}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"super/duper": {{Name: "post-test"}}},
+			},
+		},
+		{
+			name: "empty part leads to dest",
+			dest: &prowconfig.JobConfig{
+				Presubmits:  map[string][]prowconfig.Presubmit{"super/duper": {{Name: "test"}}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"super/duper": {{Name: "post-test"}}},
+			},
+			part: &prowconfig.JobConfig{},
+			expected: &prowconfig.JobConfig{
+				Presubmits:  map[string][]prowconfig.Presubmit{"super/duper": {{Name: "test"}}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"super/duper": {{Name: "post-test"}}},
+			},
+		},
+		{
+			name: "data in both leads to merge",
+			dest: &prowconfig.JobConfig{
+				Presubmits:  map[string][]prowconfig.Presubmit{"super/duper": {{Name: "test"}}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"super/duper": {{Name: "post-test"}}},
+			},
+			part: &prowconfig.JobConfig{
+				Presubmits:  map[string][]prowconfig.Presubmit{"super/duper": {{Name: "test-2"}}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"super/duper": {{Name: "post-test-2"}}},
+			},
+			expected: &prowconfig.JobConfig{
+				Presubmits:  map[string][]prowconfig.Presubmit{"super/duper": {{Name: "test"}, {Name: "test-2"}}},
+				Postsubmits: map[string][]prowconfig.Postsubmit{"super/duper": {{Name: "post-test"}, {Name: "post-test-2"}}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mergeConfigs(testCase.dest, testCase.part)
+			if actual, expected := testCase.dest, testCase.expected; !equality.Semantic.DeepEqual(actual, expected) {
+				t.Errorf("%s: wanted to get %v, got %v", testCase.name, expected, actual)
+			}
+		})
+	}
+}
+
+func TestMergeJobConfig(t *testing.T) {
+	tests := []struct {
+		destination, source, expected *prowconfig.JobConfig
+	}{
+		{
+			destination: &prowconfig.JobConfig{},
+			source: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+				}},
+			},
+			expected: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+				}},
+			},
+		}, {
+			destination: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "another-job", Context: "ci/prow/another"},
+				}},
+			},
+			source: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+				}},
+			},
+			expected: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "source-job", Context: "ci/prow/source"},
+					{Name: "another-job", Context: "ci/prow/another"},
+				}},
+			},
+		}, {
+			destination: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "same-job", Context: "ci/prow/same"},
+				}},
+			},
+			source: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "same-job", Context: "ci/prow/different"},
+				}},
+			},
+			expected: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{Name: "same-job", Context: "ci/prow/different"},
+				}},
+			},
+		}, {
+			destination: &prowconfig.JobConfig{},
+			source: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+				}},
+			},
+			expected: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+				}},
+			},
+		}, {
+			destination: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "another-job", Agent: "ci/prow/another"},
+				}},
+			},
+			source: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+				}},
+			},
+			expected: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "source-job", Agent: "ci/prow/source"},
+					{Name: "another-job", Agent: "ci/prow/another"},
+				}},
+			},
+		}, {
+			destination: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
+			},
+			source: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/different"},
+				}},
+			},
+			expected: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/different"},
+				}},
+			},
+		}, {
+			destination: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
+			},
+			source: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
+			},
+			expected: &prowconfig.JobConfig{
+				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {
+					{Name: "same-job", Agent: "ci/prow/same"},
+				}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		mergeJobConfig(tc.destination, tc.source)
+
+		if !equality.Semantic.DeepEqual(tc.destination, tc.expected) {
+			t.Errorf("expected merged job config diff:\n%s", diff.ObjectDiff(tc.expected, tc.destination))
+		}
+	}
+}

--- a/test/integration/data/input/config/super/duper/master.yaml
+++ b/test/integration/data/input/config/super/duper/master.yaml
@@ -1,0 +1,27 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+tests:
+- as: unit
+  commands: make test-unit
+  from: src
+- as: lint
+  commands: make test-lint
+  from: src

--- a/test/integration/data/input/config/super/duper/release-3.11.yaml
+++ b/test/integration/data/input/config/super/duper/release-3.11.yaml
@@ -1,0 +1,27 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v3.11
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v3.11
+  namespace: openshift
+  tag: ''
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+tests:
+- as: unit
+  commands: make test-unit
+  from: src
+- as: lint
+  commands: make test-lint
+  from: src

--- a/test/integration/data/input/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -1,0 +1,9 @@
+postsubmits:
+  super/duper:
+  - agent: jenkins
+    branches:
+    - master
+    name: branch-ci-super-duper-master-legacy
+    always_run: true
+    labels:
+      master: ci.openshift.redhat.com

--- a/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -1,0 +1,12 @@
+presubmits:
+  super/duper:
+  - agent: jenkins
+    branches:
+    - master
+    name: pull-ci-super-duper-master-legacy
+    always_run: true
+    context: ci/openshift-jenkins/jegacy
+    labels:
+      master: ci.openshift.redhat.com
+    rerun_command: /test legacy
+    trigger: ((?m)^/test( all| legacy),?(\s+|$))

--- a/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -5,8 +5,16 @@ presubmits:
     - master
     name: pull-ci-super-duper-master-legacy
     always_run: true
-    context: ci/openshift-jenkins/jegacy
+    context: ci/openshift-jenkins/legacy
     labels:
       master: ci.openshift.redhat.com
     rerun_command: /test legacy
     trigger: ((?m)^/test( all| legacy),?(\s+|$))
+  - agent: jenkins
+    name: pull-ci-super-duper-oldschool
+    always_run: true
+    context: ci/openshift-jenkins/oldschool
+    labels:
+      master: ci.openshift.redhat.com
+    rerun_command: /test oldschool
+    trigger: ((?m)^/test( all| oldschool),?(\s+|$))

--- a/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -5,6 +5,6 @@ postsubmits:
     - release-3.11
     name: branch-ci-super-duper-release-3.11-legacy
     always_run: true
-    context: ci/openshift-jenkins/jegacy
+    context: ci/openshift-jenkins/legacy
     labels:
       master: ci.openshift.redhat.com

--- a/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -1,0 +1,10 @@
+postsubmits:
+  super/duper:
+  - agent: jenkins
+    branches:
+    - release-3.11
+    name: branch-ci-super-duper-release-3.11-legacy
+    always_run: true
+    context: ci/openshift-jenkins/jegacy
+    labels:
+      master: ci.openshift.redhat.com

--- a/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     - release-3.11
     name: pull-ci-super-duper-release-3.11-legacy
     always_run: true
-    context: ci/openshift-jenkins/jegacy
+    context: ci/openshift-jenkins/legacy
     labels:
       master: ci.openshift.redhat.com
     rerun_command: /test legacy

--- a/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -1,0 +1,12 @@
+presubmits:
+  super/duper:
+  - agent: jenkins
+    branches:
+    - release-3.11
+    name: pull-ci-super-duper-release-3.11-legacy
+    always_run: true
+    context: ci/openshift-jenkins/jegacy
+    labels:
+      master: ci.openshift.redhat.com
+    rerun_command: /test legacy
+    trigger: ((?m)^/test( all| legacy),?(\s+|$))

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -1,0 +1,38 @@
+postsubmits:
+  super/duper:
+  - agent: kubernetes
+    branches:
+    - master
+    decorate: true
+    labels:
+      artifacts: images
+    name: branch-ci-super-duper-master-images
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=[images]
+        - --promote
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: master.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+  - agent: jenkins
+    branches:
+    - master
+    labels:
+      master: ci.openshift.redhat.com
+    name: branch-ci-super-duper-master-legacy

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -23,6 +23,7 @@ postsubmits:
               key: master.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -1,0 +1,105 @@
+presubmits:
+  super/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/images
+    decorate: true
+    name: pull-ci-super-duper-master-images
+    rerun_command: /test images
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=[images]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: master.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: ((?m)^/test( all| images),?(\s+|$))
+  - agent: jenkins
+    always_run: true
+    branches:
+    - master
+    context: ci/openshift-jenkins/jegacy
+    labels:
+      master: ci.openshift.redhat.com
+    name: pull-ci-super-duper-master-legacy
+    rerun_command: /test legacy
+    trigger: ((?m)^/test( all| legacy),?(\s+|$))
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/lint
+    decorate: true
+    name: pull-ci-super-duper-master-lint
+    rerun_command: /test lint
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: master.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: ((?m)^/test( all| lint),?(\s+|$))
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/unit
+    decorate: true
+    name: pull-ci-super-duper-master-unit
+    rerun_command: /test unit
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: master.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: ((?m)^/test( all| unit),?(\s+|$))

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -23,6 +23,7 @@ presubmits:
               key: master.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:
@@ -35,7 +36,7 @@ presubmits:
     always_run: true
     branches:
     - master
-    context: ci/openshift-jenkins/jegacy
+    context: ci/openshift-jenkins/legacy
     labels:
       master: ci.openshift.redhat.com
     name: pull-ci-super-duper-master-legacy
@@ -64,6 +65,7 @@ presubmits:
               key: master.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:
@@ -95,6 +97,7 @@ presubmits:
               key: master.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:
@@ -103,3 +106,11 @@ presubmits:
             cpu: 10m
       serviceAccountName: ci-operator
     trigger: ((?m)^/test( all| unit),?(\s+|$))
+  - agent: jenkins
+    always_run: true
+    context: ci/openshift-jenkins/oldschool
+    labels:
+      master: ci.openshift.redhat.com
+    name: pull-ci-super-duper-oldschool
+    rerun_command: /test oldschool
+    trigger: ((?m)^/test( all| oldschool),?(\s+|$))

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -1,0 +1,38 @@
+postsubmits:
+  super/duper:
+  - agent: kubernetes
+    branches:
+    - release-3.11
+    decorate: true
+    labels:
+      artifacts: images
+    name: branch-ci-super-duper-release-3.11-images
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=[images]
+        - --promote
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: release-3.11.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+  - agent: jenkins
+    branches:
+    - release-3.11
+    labels:
+      master: ci.openshift.redhat.com
+    name: branch-ci-super-duper-release-3.11-legacy

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -23,6 +23,7 @@ postsubmits:
               key: release-3.11.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -1,0 +1,105 @@
+presubmits:
+  super/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-3.11
+    context: ci/prow/images
+    decorate: true
+    name: pull-ci-super-duper-release-3.11-images
+    rerun_command: /test images
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=[images]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: release-3.11.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: ((?m)^/test( all| images),?(\s+|$))
+  - agent: jenkins
+    always_run: true
+    branches:
+    - release-3.11
+    context: ci/openshift-jenkins/jegacy
+    labels:
+      master: ci.openshift.redhat.com
+    name: pull-ci-super-duper-release-3.11-legacy
+    rerun_command: /test legacy
+    trigger: ((?m)^/test( all| legacy),?(\s+|$))
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-3.11
+    context: ci/prow/lint
+    decorate: true
+    name: pull-ci-super-duper-release-3.11-lint
+    rerun_command: /test lint
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=lint
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: release-3.11.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: ((?m)^/test( all| lint),?(\s+|$))
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - release-3.11
+    context: ci/prow/unit
+    decorate: true
+    name: pull-ci-super-duper-release-3.11-unit
+    rerun_command: /test unit
+    skip_cloning: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: release-3.11.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: ((?m)^/test( all| unit),?(\s+|$))

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -23,6 +23,7 @@ presubmits:
               key: release-3.11.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:
@@ -35,7 +36,7 @@ presubmits:
     always_run: true
     branches:
     - release-3.11
-    context: ci/openshift-jenkins/jegacy
+    context: ci/openshift-jenkins/legacy
     labels:
       master: ci.openshift.redhat.com
     name: pull-ci-super-duper-release-3.11-legacy
@@ -64,6 +65,7 @@ presubmits:
               key: release-3.11.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:
@@ -95,6 +97,7 @@ presubmits:
               key: release-3.11.yaml
               name: ci-operator-super-duper
         image: ci-operator:latest
+        imagePullPolicy: Always
         name: ""
         resources:
           limits:

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# This test runs a full generation on input data
+# and ensures we match the desired output.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+workdir="$( mktemp -d )"
+trap 'rm -rf "${workdir}"' EXIT
+
+data_dir="$( dirname "${BASH_SOURCE[0]}" )/data"
+input_config_dir="${data_dir}/input/config"
+input_jobs_dir="${data_dir}/input/jobs"
+generated_output_jobs_dir="${workdir}/jobs"
+expected_output_jobs_dir="${data_dir}/output/jobs"
+
+mkdir -p "${generated_output_jobs_dir}"
+cp -r "${input_jobs_dir}" "${workdir}"
+
+echo "[INFO] Generating Prow jobs..."
+ci-operator-prowgen --from-dir "${input_config_dir}" --to-dir "${generated_output_jobs_dir}"
+
+echo "[INFO] Validating generated Prow jobs..."
+if ! diff -Naupr "${expected_output_jobs_dir}" "${generated_output_jobs_dir}"> "${workdir}/diff"; then
+  cat << EOF
+[ERROR] Incorrect Prow jobs were generated!
+[ERROR] The following errors were found:
+
+EOF
+  cat "${workdir}/diff"
+  exit 1
+fi
+
+determinized_output_jobs_dir="${workdir}/determinized"
+mkdir -p "${determinized_output_jobs_dir}"
+cp -r "${generated_output_jobs_dir}"/* "${determinized_output_jobs_dir}"
+
+echo "[INFO] Determinizing Prow jobs..."
+determinize-prow-jobs --prow-jobs-dir "${determinized_output_jobs_dir}"
+
+echo "[INFO] Validating determinized Prow jobs..."
+if ! diff -Naupr "${determinized_output_jobs_dir}" "${generated_output_jobs_dir}"> "${workdir}/diff"; then
+  cat << EOF
+[ERROR] Prow job generator did not output determinized jobs!
+[ERROR] The following errors were found:
+
+EOF
+  cat "${workdir}/diff"
+  exit 1
+fi
+
+echo "[INFO] Success!"


### PR DESCRIPTION
We want to enforce that jobs are sharded by the branch and the job type,
which we can only do if we load and write at the directory level,
instead of the single file level. This patch reconfigured the generator
and the determinizer to operate at the directory level and to shard jobs
by branch and by job type.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @petr-muller 