### PR TITLE
Honor specific fields in Prow configuration

### DIFF
--- a/GENERATOR.md
+++ b/GENERATOR.md
@@ -38,6 +38,17 @@ array, generate a presubmit running ci-operator to build the `[images]` target.
     ...
 ```
 
+### Hand-Edited Prow Configuration
+
+If the existing Prow job configuration already exists, the generator will update it. The
+following fields will not be overwritten if they are already present:
+
+ - `always_run`
+ - `run_if_changed`
+ - `optional`
+ - `max_concurrency`
+ - `skip_report`
+
 ## Postsubmits
 
 ### Images
@@ -66,3 +77,10 @@ and this namespace is called `openshift`, this postsubmit job will also have `ar
       artifacts: images
     ...
 ```
+
+### Hand-Edited Prow Configuration
+
+If the existing Prow job configuration already exists, the generator will update it. The
+following fields will not be overwritten if they are already present:
+
+ - `max_concurrency`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Alternatively, you may obtain a containerized version from the registry on
 $ docker pull registry.svc.ci.openshift.org/ci/ci-operator-prowgen:latest
 ```
 
-### Generate Prow jobs for new ci-operator config file
+### Generate Prow jobs for new ci-operator config
 
 The generator can use the naming conventions and directory structure of the
 [openshift/release](https://github.com/openshift/release) repository. Provided
@@ -44,12 +44,12 @@ you may run the following (`$REPO is a path to `openshift/release` working
 copy):
 
 ```
-$ ./ci-operator-prowgen --from-file $REPO/ci-operator/config/org/component/branch.yaml \
+$ ./ci-operator-prowgen --from-dir $REPO/ci-operator/config/org/component/ \
  --to-dir $REPO/ci-operator/jobs
 ```
 
 This extracts the `org` and `component` from the configuration file path, reads
-the `branch.yaml` file and generates new Prow job configuration files in the
+the configuration files and generates new Prow job configuration files in the
 `(...)/ci-operator/jobs/` directory, creating the necessary directory structure
 and files if needed. If the target files already exist and contain Prow job
 configuration, newly generated jobs will be merged with the old ones (jobs are

--- a/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -1,5 +1,40 @@
 presubmits:
   super/duper:
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - master
+    context: ci/prow/images
+    decorate: true
+    max_concurrency: 100
+    name: pull-ci-super-duper-master-images
+    optional: true
+    rerun_command: /test images
+    run_if_changed: changes
+    skip_cloning: true
+    skip_report: true
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --target=[images]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: master.yaml
+              name: ci-operator-super-duper
+        image: ci-operator:latest
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: ((?m)^/test( all| images),?(\s+|$))
   - agent: jenkins
     branches:
     - master

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -1,14 +1,18 @@
 presubmits:
   super/duper:
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - master
     context: ci/prow/images
     decorate: true
+    max_concurrency: 100
     name: pull-ci-super-duper-master-images
+    optional: true
     rerun_command: /test images
+    run_if_changed: changes
     skip_cloning: true
+    skip_report: true
     spec:
       containers:
       - args:


### PR DESCRIPTION
Honor specific fields in Prow configuration

There exist fields in the Prow Job configuation that are only germane to
the Prow triggering and scheduling algorithms. We cannot have the source
of truth for these fields living in the CI Operator configuration, but
we can set defaults for these fields using the generator. While the
defaults will be generally applicable, we cannot ensure that they will
be valid in all cases. This patch allows changes to those fields to be
honored by the generator to allow users that opt into that level of
configuration complexity leeway when changing job configuration.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Depends on #19 
/assign @petr-muller @bbguimaraes 