### PR TITLE
Ensure all additional args are in the --key=val form

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -76,6 +76,12 @@ func (o *options) process() error {
 // Various pieces are derived from `org`, `repo`, `branch` and `target`.
 // `additionalArgs` are passed as additional arguments to `ci-operator`
 func generatePodSpec(configFile, target string, additionalArgs ...string) *kubeapi.PodSpec {
+	for _, arg := range additionalArgs {
+		if !strings.HasPrefix(arg, "--") {
+			panic(fmt.Sprintf("all args to ci-operator must be in the form --flag=value, not %s", arg))
+		}
+	}
+
 	configMapKeyRef := kubeapi.EnvVarSource{
 		ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
 			LocalObjectReference: kubeapi.LocalObjectReference{

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -62,7 +62,7 @@ func TestGeneratePodSpec(t *testing.T) {
 		{
 			configFile:     "config.yml",
 			target:         "target",
-			additionalArgs: []string{"--promote", "something"},
+			additionalArgs: []string{"--promote", "--some=thing"},
 
 			expected: &kubeapi.PodSpec{
 				ServiceAccountName: "ci-operator",
@@ -70,7 +70,7 @@ func TestGeneratePodSpec(t *testing.T) {
 					Image:           "ci-operator:latest",
 					ImagePullPolicy: kubeapi.PullAlways,
 					Command:         []string{"ci-operator"},
-					Args:            []string{"--give-pr-author-access-to-namespace=true", "--artifact-dir=$(ARTIFACTS)", "--target=target", "--promote", "something"},
+					Args:            []string{"--give-pr-author-access-to-namespace=true", "--artifact-dir=$(ARTIFACTS)", "--target=target", "--promote", "--some=thing"},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 						Limits:   kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(500, resource.DecimalSI)},
@@ -181,7 +181,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				configFilename: "branch.yaml",
 			},
 			labels:         map[string]string{},
-			additionalArgs: []string{"--promote", "additionalArg"},
+			additionalArgs: []string{"--promote", "--additional=Arg"},
 
 			expected: &prowconfig.Postsubmit{
 				Agent:    "kubernetes",
@@ -202,7 +202,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				configFilename: "config.yaml",
 			},
 			labels:         map[string]string{"artifacts": "images"},
-			additionalArgs: []string{"--promote", "additionalArg"},
+			additionalArgs: []string{"--promote", "--additional=Arg"},
 
 			expected: &prowconfig.Postsubmit{
 				Agent:    "kubernetes",


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller 

We have a couple options:

 - enforce this in review only
 - use a panic like this
 - enforce this downstream of the spec generation somewhere by adding an optional `error` return to everything

What do you think is better?