### PR TITLE
Ensure all images to promote are targeted

### DIFF
--- a/test/integration/data/input/config/super/duper/release-3.11.yaml
+++ b/test/integration/data/input/config/super/duper/release-3.11.yaml
@@ -25,3 +25,6 @@ tests:
 - as: lint
   commands: make test-lint
   from: src
+promotion:
+  additional_images:
+    super-duper-src: src

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -15,6 +15,7 @@ postsubmits:
         - --give-pr-author-access-to-namespace=true
         - --promote
         - --target=[images]
+        - --target=src
         command:
         - ci-operator
         env:


### PR DESCRIPTION
When a promotion configuration targets specific images outside of
[images] we need to explicitly target all of them to ensure they exist
at promotion time.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller @smarterclayton 