### PR TITLE
Add new cluster profiles - aws-gluster and gcp-logging

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -127,9 +127,9 @@ func generatePodSpecTemplate(org, repo, configFile, release string, test *cioper
 	}
 	var targetCloud string
 	switch clusterProfile {
-	case cioperatorapi.ClusterProfileAWS, cioperatorapi.ClusterProfileAWSAtomic, cioperatorapi.ClusterProfileAWSCentos:
+	case cioperatorapi.ClusterProfileAWS, cioperatorapi.ClusterProfileAWSAtomic, cioperatorapi.ClusterProfileAWSCentos, ClusterProfileAWSGluster:
 		targetCloud = "aws"
-	case cioperatorapi.ClusterProfileGCP, cioperatorapi.ClusterProfileGCPHA, cioperatorapi.ClusterProfileGCPCRIO:
+	case cioperatorapi.ClusterProfileGCP, cioperatorapi.ClusterProfileGCPHA, cioperatorapi.ClusterProfileGCPCRIO, ClusterProfileGCPLogging:
 		targetCloud = "gcp"
 	}
 	clusterProfilePath := fmt.Sprintf("/usr/local/%s-cluster-profile", test.As)


### PR DESCRIPTION
Add new cluster types, requires https://github.com/openshift/ci-operator/pull/176

Now sure if I should bump up ci-operator dep manually or its gonna happen automagically