### PR TITLE
When generating the postsubmit images job, only promote on exact matches

### DIFF
--- a/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -2,7 +2,7 @@ postsubmits:
   super/duper:
   - agent: kubernetes
     branches:
-    - master
+    - ^master$
     decorate: true
     labels:
       artifacts: images

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -2,7 +2,7 @@ postsubmits:
   super/duper:
   - agent: kubernetes
     branches:
-    - release-3.11
+    - ^release-3\.11$
     decorate: true
     labels:
       artifacts: images


### PR DESCRIPTION
Because prowjob branches are regexps, the "master" branch matches
`.*master.*`. If a team has a working branch like `master-dockerless`
and merges to that branch, the promote images job will stomp the images
that the `master` branch promotes.

With this change, the image promotion job is set to exactly match the
requested branch, unless the branch looks like a regex (has characters
outside the normal branch name set). This prevents accidental image
promotion that occurs on feature branches.

Yesterday master jobs were broken for several hours because the master-dockerless
branch was pushed to and the promotion job promoted it to openshift/origin-v4.0,
overwriting the artifacts image with the contents of that branch (it is much older)
and causing older RPMs to not be served.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.0/768