### PR TITLE
Fix template name for custom openshift-ansible provisioner

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -123,7 +123,7 @@ func generatePodSpecTemplate(org, repo, configFile, release string, test *cioper
 		clusterProfile = conf.ClusterProfile
 		needsReleaseRpms = true
 	} else if conf := test.OpenshiftAnsibleCustomClusterTestConfiguration; conf != nil {
-		template = "cluster-launch-openshift-ansible"
+		template = "cluster-launch-e2e-openshift-ansible"
 		clusterProfile = conf.ClusterProfile
 		needsReleaseRpms = true
 	} else if conf := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; conf != nil {


### PR DESCRIPTION
Wrong template name for custom provisioner was used, see 
https://github.com/openshift/release/pull/1923/files#r225149259