### PR TITLE
Openshift installer src template

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -152,11 +152,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:899e1f88495a27bfbddcd4b12d624896c976f6e0f581ec6b60645cb8d93e8032"
+  digest = "1:cc55697380c2a5a47cdcd27624e3a6e19fe2514d520b5d1c3fbeffde21f249c6"
   name = "github.com/openshift/ci-operator"
   packages = ["pkg/api"]
   pruneopts = ""
-  revision = "2e1b47b955507029cd12ddc9f04905899d01fb61"
+  revision = "c1f891389b2431c2c455aa5b7e15a82a67703512"
 
 [[projects]]
   digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -133,6 +133,9 @@ func generatePodSpecTemplate(org, repo, configFile, release string, test *cioper
 	} else if conf := test.OpenshiftInstallerClusterTestConfiguration; conf != nil {
 		template = "cluster-launch-installer-e2e"
 		clusterProfile = conf.ClusterProfile
+	} else if conf := test.OpenshiftInstallerSrcClusterTestConfiguration; conf != nil {
+		template = "cluster-launch-installer-src"
+		clusterProfile = conf.ClusterProfile
 	}
 	var targetCloud string
 	switch clusterProfile {

--- a/vendor/github.com/openshift/ci-operator/CONFIGURATION.md
+++ b/vendor/github.com/openshift/ci-operator/CONFIGURATION.md
@@ -77,6 +77,8 @@ tests:
     previous_rpm_deps: ''
   openshift_installer:
     cluster_profile: ''
+  openshift_installer_src:
+    cluster_profile: ''
 ```
 
 # `tag_specification`
@@ -330,6 +332,10 @@ and runs conformance tests.
 ## `tests.openshift_installer`
 `openshift_installer` is a test that provisions a cluster using
 `openshift-installer` and runs conformance tests.
+
+## `tests.openshift_installer_src`
+`openshift_installer_src` is a test that provisions a cluster using
+`openshift-installer` and executes a test in the `src` image.
 
 ## `tests.*.cluster_profile`
 `cluster_profile` chooses the profile used as input to the installer. This

--- a/vendor/github.com/openshift/ci-operator/TEMPLATES.md
+++ b/vendor/github.com/openshift/ci-operator/TEMPLATES.md
@@ -109,5 +109,5 @@ Comma-separated list of container names for which ci-operator will wait until co
 to gather the artifacts.
 
 `ci-operator.openshift.io/containers-logged-on-failure`:
-Comma-separated list of container names for which ci-operator will collect and log their output if pod fails.
-By default, only the logs from the failed containers will be output.
+Comma-separated list of container names for which ci-operator will collect and log their output to artifacts if pod fails.
+The artifact names will be generated in the format of `$container_name.log` in the `container-logs` directory.

--- a/vendor/github.com/openshift/ci-operator/pkg/api/config.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/api/config.go
@@ -212,6 +212,10 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
 	}
+	if testConfig := test.OpenshiftInstallerSrcClusterTestConfiguration; testConfig != nil {
+		typeCount++
+		validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile))
+	}
 	if typeCount == 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("%s has no type", fieldRoot))
 	} else if typeCount == 1 {

--- a/vendor/github.com/openshift/ci-operator/pkg/api/types.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/api/types.go
@@ -289,6 +289,7 @@ type TestStepConfiguration struct {
 	OpenshiftAnsibleCustomClusterTestConfiguration  *OpenshiftAnsibleCustomClusterTestConfiguration  `json:"openshift_ansible_custom,omitempty"`
 	OpenshiftAnsibleUpgradeClusterTestConfiguration *OpenshiftAnsibleUpgradeClusterTestConfiguration `json:"openshift_ansible_upgrade,omitempty"`
 	OpenshiftInstallerClusterTestConfiguration      *OpenshiftInstallerClusterTestConfiguration      `json:"openshift_installer,omitempty"`
+	OpenshiftInstallerSrcClusterTestConfiguration   *OpenshiftInstallerSrcClusterTestConfiguration   `json:"openshift_installer_src,omitempty"`
 }
 
 // ContainerTestConfiguration describes a test that runs a
@@ -356,6 +357,13 @@ type OpenshiftAnsibleUpgradeClusterTestConfiguration struct {
 // that provisions a cluster using openshift-installer and runs
 // conformance tests.
 type OpenshiftInstallerClusterTestConfiguration struct {
+	ClusterTestConfiguration `json:",inline"`
+}
+
+// OpenshiftInstallerSrcClusterTestConfiguration describes a
+// test that provisions a cluster using openshift-installer and
+// executes a command in the `src` image.
+type OpenshiftInstallerSrcClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 }
 

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/test.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/test.go
@@ -117,7 +117,7 @@ func (s *podStep) Run(ctx context.Context, dry bool) error {
 		return fmt.Errorf("failed to create or restart %s pod: %v", s.name, err)
 	}
 
-	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier); err != nil {
+	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier, s.artifactDir); err != nil {
 		return fmt.Errorf("failed to wait for %s pod to complete: %v", s.name, err)
 	}
 


### PR DESCRIPTION
This adds support for the cluster-launch-installer-src template, which runs a test command in the `src` image after installing a cluster with openshift installer.