### PR TITLE
Use openshift/openshift-ansible subfolder for templates

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -196,7 +196,7 @@ func generatePodSpecTemplate(org, repo, configFile, release string, test *cioper
 		fmt.Sprintf("--template=%s", templatePath))
 	container.VolumeMounts = []kubeapi.VolumeMount{
 		{Name: "cluster-profile", MountPath: clusterProfilePath},
-		{Name: "job-definition", MountPath: templatePath, SubPath: fmt.Sprintf("%s.yaml", template)},
+		{Name: "job-definition", MountPath: templatePath, SubPath: fmt.Sprintf("openshift/openshift-ansible/%s.yaml", template)},
 	}
 	container.Env = append(
 		container.Env,


### PR DESCRIPTION
This is a precondition to rework templates location so that it would easier to support 3.1x and 4.0 branches