### PR TITLE
Init: Find which presubmits have to be executed.

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/openshift/ci-operator-prowgen/pkg/diffs"
+)
+
+type options struct {
+	configPath    string
+	jobConfigPath string
+}
+
+func gatherOptions() options {
+	o := options{}
+	flag.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to Prow config.yaml")
+	flag.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
+	flag.Parse()
+	return o
+}
+
+func validateOptions(o options) error {
+	if len(o.jobConfigPath) == 0 {
+		return fmt.Errorf("empty --job-config-path")
+	}
+	return nil
+}
+
+func main() {
+	o := gatherOptions()
+	err := validateOptions(o)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	changedPresubmits, err := diffs.GetChangedPresubmits(o.configPath, o.jobConfigPath)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+
+	// just print them for now.
+	for repo, jobs := range changedPresubmits {
+		fmt.Println(repo)
+		for _, job := range jobs {
+			fmt.Println(job.Name)
+		}
+	}
+}

--- a/images/pj-rehearse/Dockerfile
+++ b/images/pj-rehearse/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+LABEL maintainer="nmoraiti@redhat.com"
+
+ADD pj-rehearse /usr/bin/pj-rehearse
+ENTRYPOINT ["/usr/bin/pj-rehearse"]

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -1,0 +1,50 @@
+package diffs
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	prowconfig "k8s.io/test-infra/prow/config"
+)
+
+// GetChangedPresubmits returns a mapping of repo to presubmits to execute.
+func GetChangedPresubmits(configPath, jobConfigPath string) (map[string][]prowconfig.Presubmit, error) {
+	ret := make(map[string][]prowconfig.Presubmit)
+
+	prowMasterConfig, err := prowconfig.Load(configPath, jobConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load master's Prow config: %v", err)
+	}
+
+	prowPRConfig, err := prowconfig.Load("./cluster/ci/config/prow/config.yaml", "./ci-operator/jobs/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load PR's Prow config: %v", err)
+	}
+
+	masterJobs := getJobsByRepoAndName(prowMasterConfig.JobConfig.Presubmits)
+	for repo, jobs := range prowPRConfig.JobConfig.Presubmits {
+		for _, job := range jobs {
+			if !equality.Semantic.DeepEqual(masterJobs[repo][job.Name].Spec, job.Spec) {
+				ret[repo] = append(ret[repo], job)
+			}
+		}
+	}
+	return ret, nil
+}
+
+// To compare two maps of slices, instead of iterating through the slice
+// and compare the same key and index of the other map of slices,
+// we convert them as `repo-> jobName-> Presubmit` to be able to
+// access any specific elements of the Presubmits without the need to iterate in slices.
+func getJobsByRepoAndName(presubmits map[string][]prowconfig.Presubmit) map[string]map[string]prowconfig.Presubmit {
+	jobsByRepo := make(map[string]map[string]prowconfig.Presubmit)
+
+	for repo, preSubmitList := range presubmits {
+		pm := make(map[string]prowconfig.Presubmit)
+		for _, p := range preSubmitList {
+			pm[p.Name] = p
+		}
+		jobsByRepo[repo] = pm
+	}
+	return jobsByRepo
+}


### PR DESCRIPTION
Compares the `presubmits` from the decorated repository and the master files.
Finds which of them shall be executed and creates a mapping of the repo to `presubmits` to execute.