### PR TITLE
Suppress rehearsing jobs with additional volumes

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -80,6 +80,10 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	gitrefArg := fmt.Sprintf("--git-ref=%s@%s", repo, branch)
 	rehearsal.Spec.Containers[0].Args = append(source.Spec.Containers[0].Args, gitrefArg)
 
+	if len(source.Spec.Volumes) > 0 {
+		return nil, fmt.Errorf("cannot rehearse jobs that need additional volumes mounted")
+	}
+
 	return &rehearsal, nil
 }
 


### PR DESCRIPTION
Mounted volumes is currently the way how the templates are passed to
ci-operator in template-based jobs, generated by Prowgen. In these jobs,
volumes for templates are populated from the appropriate ConfigMap
present in the cluster. If we attempted to rehearse these jobs, they
would also use the content in the cluster. But the templates can be
also changed in the same PR as for which we are running the rehearsal,
which means a naive rehearsal would run over a different version of the
template than the one being present if the tested PR would be merged.
Therefore, do not rehearse these jobs for now, until we have a reliable
mechanism to pass all necessary content to rehearsed jobs.

An auxiliary benefit of this suppression is that it limits job
rehearsals only to the standard, container-based jobs which tend to be
simpler, making feature simpler and less prone to bugs, which is a good
thing for an initial release.