### PR TITLE
Allow `openshift-4.0` branches to be promoted

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -350,10 +350,10 @@ func extractPromotionName(configSpec *cioperatorapi.ReleaseBuildConfiguration) s
 
 func shouldBePromoted(branch, namespace, name string) bool {
 	if namespace == "openshift" {
-		if name == "origin-v4.0" {
-			return branch == "master"
+		switch name {
+		case "origin-v4.0":
+			return branch == "master" || branch == "openshift-4.0"
 		}
-
 		// TODO: release branches?
 	}
 


### PR DESCRIPTION
Discovered in https://github.com/openshift/ci-operator-prowgen/pull/58, etcd has to have `openshift-4.0` branch because upstream has `release-X`.

I need to come back to this and make this not be a hardcoded list here.