### PR TITLE
Better logging, job validation and unitests.

### DIFF
--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -1,0 +1,153 @@
+package diffs
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	prowconfig "k8s.io/test-infra/prow/config"
+
+	"github.com/getlantern/deepcopy"
+)
+
+func TestGetChangedPresubmits(t *testing.T) {
+	basePresubmit := []prowconfig.Presubmit{
+		{
+			JobBase: prowconfig.JobBase{
+				Agent: "kubernetes",
+				Name:  "test-base-presubmit",
+				Spec: &v1.PodSpec{
+					Containers: []v1.Container{{
+						Command: []string{"ci-operator"},
+						Args:    []string{"--artifact-dir=$(ARTIFACTS)", "--target=images"},
+					}},
+				},
+			},
+			Context:  "test-base-presubmit",
+			Brancher: prowconfig.Brancher{Branches: []string{"^master$"}},
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		configGenerator func() (before, after *prowconfig.Config)
+		expected        map[string][]prowconfig.Presubmit
+	}{
+		{
+			name: "no differences mean nothing is identified as a diff",
+			configGenerator: func() (*prowconfig.Config, *prowconfig.Config) {
+				return makeConfig(basePresubmit), makeConfig(basePresubmit)
+			},
+			expected: map[string][]prowconfig.Presubmit{},
+		},
+		{
+			name: "new job added",
+			configGenerator: func() (*prowconfig.Config, *prowconfig.Config) {
+				var p []prowconfig.Presubmit
+				var pNew prowconfig.Presubmit
+				deepcopy.Copy(&p, basePresubmit)
+
+				pNew = p[0]
+				pNew.Name = "test-base-presubmit-new"
+				p = append(p, pNew)
+
+				return makeConfig(basePresubmit), makeConfig(p)
+
+			},
+			expected: map[string][]prowconfig.Presubmit{
+				"org/repo": func() []prowconfig.Presubmit {
+					var p []prowconfig.Presubmit
+					var pNew prowconfig.Presubmit
+					deepcopy.Copy(&p, basePresubmit)
+					pNew = p[0]
+					pNew.Name = "test-base-presubmit-new"
+
+					return []prowconfig.Presubmit{pNew}
+				}(),
+			},
+		},
+		{
+			name: "different agent is identified as a diff (from jenkins to kubernetes)",
+			configGenerator: func() (*prowconfig.Config, *prowconfig.Config) {
+				var p []prowconfig.Presubmit
+				deepcopy.Copy(&p, basePresubmit)
+				p[0].Agent = "jenkins"
+				return makeConfig(p), makeConfig(basePresubmit)
+
+			},
+			expected: map[string][]prowconfig.Presubmit{
+				"org/repo": basePresubmit,
+			},
+		},
+		{
+			name: "different spec is identified as a diff - single change",
+			configGenerator: func() (*prowconfig.Config, *prowconfig.Config) {
+				var p []prowconfig.Presubmit
+				deepcopy.Copy(&p, basePresubmit)
+				p[0].Spec.Containers[0].Command = []string{"test-command"}
+				return makeConfig(basePresubmit), makeConfig(p)
+
+			},
+			expected: map[string][]prowconfig.Presubmit{
+				"org/repo": func() []prowconfig.Presubmit {
+					var p []prowconfig.Presubmit
+					deepcopy.Copy(&p, basePresubmit)
+					p[0].Spec.Containers[0].Command = []string{"test-command"}
+					return p
+				}(),
+			},
+		},
+		{
+			name: "different spec is identified as a diff - massive changes",
+			configGenerator: func() (*prowconfig.Config, *prowconfig.Config) {
+				var p []prowconfig.Presubmit
+				deepcopy.Copy(&p, basePresubmit)
+				p[0].Spec.Containers[0].Command = []string{"test-command"}
+				p[0].Spec.Containers[0].Args = []string{"testarg", "testarg", "testarg"}
+				p[0].Spec.Volumes = []v1.Volume{{
+					Name: "test-volume",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					}},
+				}
+				return makeConfig(basePresubmit), makeConfig(p)
+			},
+			expected: map[string][]prowconfig.Presubmit{
+				"org/repo": func() []prowconfig.Presubmit {
+					var p []prowconfig.Presubmit
+					deepcopy.Copy(&p, basePresubmit)
+					p[0].Spec.Containers[0].Command = []string{"test-command"}
+					p[0].Spec.Containers[0].Args = []string{"testarg", "testarg", "testarg"}
+					p[0].Spec.Volumes = []v1.Volume{{
+						Name: "test-volume",
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{},
+						}},
+					}
+					return p
+				}()},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			before, after := testCase.configGenerator()
+			p, err := GetChangedPresubmits(before, after, logrus.NewEntry(logrus.New()))
+			if err != nil {
+				t.Fatalf("GetChangedPresubmits returned error: %v", err)
+			}
+			if !equality.Semantic.DeepEqual(p, testCase.expected) {
+				t.Fatalf("Name:%s\nExpected %#v\nFound:%#v\n", testCase.name, testCase.expected["org/repo"], p["org/repo"])
+			}
+		})
+	}
+}
+
+func makeConfig(p []prowconfig.Presubmit) *prowconfig.Config {
+	return &prowconfig.Config{
+		JobConfig: prowconfig.JobConfig{
+			Presubmits: map[string][]prowconfig.Presubmit{"org/repo": p},
+		},
+	}
+}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -27,7 +27,8 @@ import (
 func makeTestingPresubmitForEnv(env []v1.EnvVar) *prowconfig.Presubmit {
 	return &prowconfig.Presubmit{
 		JobBase: prowconfig.JobBase{
-			Name: "test-job-name",
+			Agent: "kubernetes",
+			Name:  "test-job-name",
 			Spec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{Env: env},
@@ -132,6 +133,7 @@ func TestInlineCiopConfig(t *testing.T) {
 func makeTestingPresubmit(name, context string, ciopArgs []string) *prowconfig.Presubmit {
 	return &prowconfig.Presubmit{
 		JobBase: prowconfig.JobBase{
+			Agent:  "kubernetes",
 			Name:   name,
 			Labels: map[string]string{rehearseLabel: "123"},
 			Spec: &v1.PodSpec{
@@ -182,11 +184,6 @@ func TestMakeRehearsalPresubmitNegative(t *testing.T) {
 		description string
 		crippleFunc func(*prowconfig.Presubmit)
 	}{{
-		description: "job with multiple containers",
-		crippleFunc: func(j *prowconfig.Presubmit) {
-			j.Spec.Containers = append(j.Spec.Containers, v1.Container{})
-		},
-	}, {
 		description: "job where command is not `ci-operator`",
 		crippleFunc: func(j *prowconfig.Presubmit) {
 			j.Spec.Containers[0].Command[0] = "not-ci-operator"
@@ -238,6 +235,7 @@ func makeTestingProwJob(name, namespace, jobName, context string, refs *pjapi.Re
 			Annotations: map[string]string{"prow.k8s.io/job": jobName},
 		},
 		Spec: pjapi.ProwJobSpec{
+			Agent:   "kubernetes",
 			Type:    pjapi.PresubmitJob,
 			Job:     jobName,
 			Refs:    refs,


### PR DESCRIPTION
Do a more detailed comparison of the jobs and output logs with the changes information.
Split the job validation logic and added unit tests for diff package.

WIP more unit tests.

Log output for the job differences examples:
```
INFO[0000] Job has been chosen for rehearsal                          diffs=" .Spec.Volumes[0].Name:   a: 'cluster-profile'   b: 'cluster-profile-test' .Spec.Volumes[0].VolumeSource.Projected.Sources[0].Secret.LocalObjectReference.Name:   a: 'cluster-secrets-aws'   b: 'clustser-secrets-aws'" job-name=pull-ci-openshift-cluster-autoscaler-operator-master-e2e-aws pr=2596 repo=openshift/cluster-autoscaler-operator
```
```
INFO[0000] Job has been chosen for rehearsal                          diffs=" .Spec.Containers[0].Args[0]:   a: '--artifact-dir=$(ARTIFACTS)'   b: '--artifact-dir=$(ASRTIFACTS)'" job-name=pull-ci-heketi-heketi-master-simple pr=2596 repo=heketi/heketi
```
```
INFO[0000] Job has been chosen for rehearsal                          diffs=" .Agent:   a: 'kubernetes'   b: 'jenkins'" job-name=pull-ci-openshift-router-master-e2e-aws pr=2596 repo=openshift/router
```