### PR TITLE
Remove assumption that tag_specification is set

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -375,7 +375,11 @@ func generateJobs(
 		if element.ContainerTestConfiguration != nil {
 			podSpec = generatePodSpec(repoInfo.configFilename, element.As)
 		} else {
-			podSpec = generatePodSpecTemplate(repoInfo.org, repoInfo.repo, repoInfo.configFilename, configSpec.ReleaseTagConfiguration.Name, &element)
+			var release string
+			if c := configSpec.ReleaseTagConfiguration; c != nil {
+				release = c.Name
+			}
+			podSpec = generatePodSpecTemplate(repoInfo.org, repoInfo.repo, repoInfo.configFilename, release, &element)
 		}
 		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(element.As, repoInfo, podSpec))
 	}

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -522,6 +522,27 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 			},
 		}, {
+			id: "template test which doesn't require `tag_specification`",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{{
+					As: "oTeste",
+					OpenshiftInstallerClusterTestConfiguration: &ciop.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
+					},
+				}},
+			},
+			repoInfo: &configFilePathElements{
+				org:            "organization",
+				repo:           "repository",
+				branch:         "branch",
+				configFilename: "konfig.yaml",
+			},
+			expected: &prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {
+					{JobBase: prowconfig.JobBase{Name: "pull-ci-organization-repository-branch-oTeste"}},
+				}},
+			},
+		}, {
 			id: "Promotion.Namespace is 'openshift' so artifact label is added",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:                  []ciop.TestStepConfiguration{},


### PR DESCRIPTION
Prevents a segfault when a configuration (correctly) omits
`tag_specification`.

Fixes #61.