### PR TITLE
Improve failure mode messaging to the user

### DIFF
--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -29,7 +29,7 @@ const (
 )
 
 // GetChangedPresubmits returns a mapping of repo to presubmits to execute.
-func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, logger *logrus.Entry) (map[string][]prowconfig.Presubmit, error) {
+func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, logger *logrus.Entry) map[string][]prowconfig.Presubmit {
 	ret := make(map[string][]prowconfig.Presubmit)
 
 	masterJobs := getJobsByRepoAndName(prowMasterConfig.JobConfig.Presubmits)
@@ -55,7 +55,7 @@ func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, log
 			}
 		}
 	}
-	return ret, nil
+	return ret
 }
 
 // To compare two maps of slices, instead of iterating through the slice

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -133,10 +133,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			before, after := testCase.configGenerator()
-			p, err := GetChangedPresubmits(before, after, logrus.NewEntry(logrus.New()))
-			if err != nil {
-				t.Fatalf("GetChangedPresubmits returned error: %v", err)
-			}
+			p := GetChangedPresubmits(before, after, logrus.NewEntry(logrus.New()))
 			if !equality.Semantic.DeepEqual(p, testCase.expected) {
 				t.Fatalf("Name:%s\nExpected %#v\nFound:%#v\n", testCase.name, testCase.expected["org/repo"], p["org/repo"])
 			}


### PR DESCRIPTION
Rehearse tool has 4 possible results:

1. There is nothing that we can rehearse. We can consider this case to be a success.
2. We attempted to rehearse some jobs and they all pass. This is also a success.
3. We attempted to rehearse some jobs and some of them failed. The whole purpose of rehearsal is to communicate these failures to the user.
4. We attempted to rehearse some jobs but failed to do so for some reason. This is the tricky case - failing on these will frustrate the users because it's usually not *their* error, but we cannot simply eat these errors because we would fake passing tests while the tests were not even executed correctly.

This change triages these failure modes and accompanies them with an
explaining outputs.

/cc @droslean @bbguimaraes @stevekuznetsov 