### PR TITLE
Generate trigger regex as upstream does

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -266,7 +266,7 @@ func generatePresubmitForTest(name string, repoInfo *configFilePathElements, pod
 		Brancher:     prowconfig.Brancher{Branches: []string{repoInfo.branch}},
 		Context:      fmt.Sprintf("ci/prow/%s", name),
 		RerunCommand: fmt.Sprintf("/test %s", name),
-		Trigger:      fmt.Sprintf(`((?m)^/test( all| %s),?(\s+|$))`, name),
+		Trigger:      fmt.Sprintf(`(?m)^/test (?:.*? )?%s(?: .*?)?$`, name),
 	}
 }
 

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -317,7 +317,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 			Brancher:     prowconfig.Brancher{Branches: []string{"branch"}},
 			Context:      "ci/prow/testname",
 			RerunCommand: "/test testname",
-			Trigger:      `((?m)^/test( all| testname),?(\s+|$))`,
+			Trigger:      "(?m)^/test (?:.*? )?testname(?: .*?)?$",
 		},
 	}}
 	for _, tc := range tests {
@@ -886,7 +886,7 @@ tests:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -920,7 +920,7 @@ tests:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| unit),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'
 `),
 		}, {
 			id:        "One test and images, one existing job. Expect one presubmit, pre/post submit images jobs. Existing job should not be changed.",
@@ -1030,7 +1030,7 @@ tests:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| rhel-images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?rhel-images(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -1066,7 +1066,7 @@ tests:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| rhel-unit),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?rhel-unit(?: .*?)?$'
 `),
 			prowExpectedPostsubmitYAML: []byte(`postsubmits:
   super/duper:
@@ -1241,7 +1241,7 @@ tests:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -1275,7 +1275,7 @@ tests:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| unit),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'
 `),
 			prowExpectedPostsubmitYAML: []byte(`postsubmits:
   super/duper:

--- a/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -34,7 +34,7 @@ presubmits:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: jenkins
     branches:
     - master

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -60,7 +60,7 @@ presubmits:
       - configMap:
           name: prow-job-cluster-launch-e2e
         name: job-definition
-    trigger: ((?m)^/test( all| e2e),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?e2e(?: .*?)?$'
   - agent: kubernetes
     always_run: false
     branches:
@@ -99,7 +99,7 @@ presubmits:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: jenkins
     always_run: true
     branches:
@@ -143,7 +143,7 @@ presubmits:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| lint),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?lint(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -177,7 +177,7 @@ presubmits:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| unit),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'
   - agent: jenkins
     always_run: true
     context: ci/openshift-jenkins/oldschool

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: jenkins
     always_run: true
     branches:
@@ -77,7 +77,7 @@ presubmits:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| lint),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?lint(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -111,4 +111,4 @@ presubmits:
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| unit),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'


### PR DESCRIPTION
We should not be matching the literal `/test all` with our triggers.
It's not best practice and should be avoided. This patch refactors our
trigger generation to use the same logic as the upstream defaulting
would, generating the identical regex for a job name as would happen if
no regex was present in the Prow config at all. We still need to
generate our own as we want the name in the regex to be a subset of the
full name of the job.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>