### PR TITLE
Force rehearsals to have an unified trigger

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	rehearseLabel = "ci.openshift.org/rehearse"
+	rehearseLabel                = "ci.openshift.org/rehearse"
+	defaultRehearsalRerunCommand = "/test pj-rehearse"
 )
 
 type Loggers struct {
@@ -72,6 +73,7 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	branch := strings.TrimPrefix(strings.TrimSuffix(source.Branches[0], "$"), "^")
 	shortName := strings.TrimPrefix(source.Context, "ci/prow/")
 	rehearsal.Context = fmt.Sprintf("ci/rehearse/%s/%s/%s", repo, branch, shortName)
+	rehearsal.RerunCommand = defaultRehearsalRerunCommand
 
 	gitrefArg := fmt.Sprintf("--git-ref=%s@%s", repo, branch)
 	rehearsal.Spec.Containers[0].Args = append(source.Spec.Containers[0].Args, gitrefArg)


### PR DESCRIPTION
Rehearsals cannot be triggered directly (Prow will only kick jobs that
are configured for the given repo on /test XXX commands), so we
work around it by making it share RerunCommand with the `pj-rehearse`
job (the driver). RerunCommand is only used to give users hints in a
comment, so this just makes the bot stop suggesting comments that would
not work.

I've also simplified the affected test and made it less coupled with the others.

/cc @stevekuznetsov @bbguimaraes @droslean 