### PR TITLE
Strip CPU limits from prowjobs directly due to cfs_quota issues

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -107,7 +107,6 @@ func generatePodSpec(configFile, target string, additionalArgs ...string) *kubea
 				Env:             []kubeapi.EnvVar{{Name: "CONFIG_SPEC", ValueFrom: &configMapKeyRef}},
 				Resources: kubeapi.ResourceRequirements{
 					Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					Limits:   kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(500, resource.DecimalSI)},
 				},
 			},
 		},

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -43,7 +43,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Args:            []string{"--give-pr-author-access-to-namespace=true", "--artifact-dir=$(ARTIFACTS)", "--target=target"},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-						Limits:   kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(500, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{{
 						Name: "CONFIG_SPEC",
@@ -73,7 +72,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Args:            []string{"--give-pr-author-access-to-namespace=true", "--artifact-dir=$(ARTIFACTS)", "--target=target", "--promote", "--some=thing"},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-						Limits:   kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(500, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{{
 						Name: "CONFIG_SPEC",
@@ -176,7 +174,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--template=/usr/local/test"},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-						Limits:   kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(500, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
 						{
@@ -257,7 +254,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--template=/usr/local/test"},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-						Limits:   kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(500, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
 						{
@@ -845,8 +841,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -881,8 +875,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -915,8 +907,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -987,8 +977,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1025,8 +1013,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1061,8 +1047,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1096,8 +1080,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1131,8 +1113,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1200,8 +1180,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1236,8 +1214,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1270,8 +1246,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1303,8 +1277,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -1337,8 +1309,6 @@ tests:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator

--- a/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/input/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -29,8 +29,6 @@ presubmits:
         image: ci-operator:latest
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -29,8 +29,6 @@ postsubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator

--- a/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -38,8 +38,6 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
         volumeMounts:
@@ -94,8 +92,6 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -138,8 +134,6 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -172,8 +166,6 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -30,8 +30,6 @@ postsubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator

--- a/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -28,8 +28,6 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -72,8 +70,6 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
@@ -106,8 +102,6 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator


### PR DESCRIPTION
cfs_quota has challenges when it comes to distributing CPU and we
currently suspect use of limits is causing CPU inversion (processes
stall for long periods of time without CPU). Remove the generated
limits from prowjobs.