### PR TITLE
Limit rehearsals to 15 jobs

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -206,6 +206,8 @@ func configureRehearsalJobs(toBeRehearsed map[string][]prowconfig.Presubmit, prR
 
 // Executor holds all the information needed for the jobs to be executed.
 type Executor struct {
+	RehearsalJobCount int
+
 	dryRun     bool
 	rehearsals []*prowconfig.Presubmit
 	prNumber   int
@@ -220,6 +222,8 @@ func NewExecutor(toBeRehearsed map[string][]prowconfig.Presubmit, prNumber int, 
 	dryRun bool, loggers Loggers, pjclient pj.ProwJobInterface) *Executor {
 	rehearsals := configureRehearsalJobs(toBeRehearsed, prRepo, prNumber, loggers)
 	return &Executor{
+		RehearsalJobCount: len(rehearsals),
+
 		dryRun:     dryRun,
 		rehearsals: rehearsals,
 		prNumber:   prNumber,


### PR DESCRIPTION
I'd like to consider something like this to go along fully enabling rehearsals in https://github.com/openshift/release/pull/2847

I'm concerned whether it's fine to mass-submit hundreds of prowjobs for changes like yesterday's https://github.com/openshift/release/pull/2834. It seems that GH has a limit of 1000 statuses per SHA so we're fine on that front, but I'm not sure about our test throughput. Also, we'll probably not care that much about jobs themselves when we do mass changes.

WDYT?

/cc @stevekuznetsov @droslean @bbguimaraes 