### PR TITLE
Images in the 'ocp' namespace should have the release payload

### DIFF
--- a/GENERATOR.md
+++ b/GENERATOR.md
@@ -65,19 +65,6 @@ promote the component images built by this postsubmit.
     ...
 ```
 
-If the configuration file specifies a promotion namespace, either in
-[promotion.namespace](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#promotionnamespace)
-or in
-[tag_specification.namespace](https://github.com/openshift/ci-operator/blob/master/CONFIGURATION.md#tag_specificationnamespace),
-and this namespace is called `openshift`, this postsubmit job will also have `artifacts: images` label:
-
-```yaml
-  - name: branch-ci-ORG-REPO-BRANCH-images
-    labels:
-      artifacts: images
-    ...
-```
-
 ### Hand-Edited Prow Configuration
 
 If the existing Prow job configuration already exists, the generator will update it. The

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -556,9 +556,7 @@ func TestGenerateJobs(t *testing.T) {
 					{JobBase: prowconfig.JobBase{Name: "pull-ci-organization-repository-branch-images"}},
 				}},
 				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{Name: "branch-ci-organization-repository-branch-images",
-						Labels: map[string]string{"artifacts": "images"},
-					},
+					JobBase: prowconfig.JobBase{Name: "branch-ci-organization-repository-branch-images"},
 				}}},
 			},
 		}, {
@@ -603,8 +601,7 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
-						Name:   "branch-ci-organization-repository-branch-images",
-						Labels: map[string]string{"artifacts": "images"},
+						Name: "branch-ci-organization-repository-branch-images",
 					}}},
 				}},
 		}, {
@@ -676,8 +673,7 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
-						Name:   "branch-ci-organization-repository-branch-images",
-						Labels: map[string]string{"artifacts": "images"},
+						Name: "branch-ci-organization-repository-branch-images",
 					}}}},
 			},
 		},
@@ -819,8 +815,6 @@ tests:
     decorate: true
     decoration_config:
       skip_cloning: true
-    labels:
-      artifacts: images
     name: branch-ci-super-duper-branch-images
     spec:
       containers:
@@ -1091,7 +1085,6 @@ tests:
     decoration_config:
       skip_cloning: true
     labels:
-      artifacts: images
       ci-operator.openshift.io/variant: rhel
     name: branch-ci-super-duper-branch-rhel-images
     spec:
@@ -1287,8 +1280,6 @@ tests:
     decorate: true
     decoration_config:
       skip_cloning: true
-    labels:
-      artifacts: images
     name: branch-ci-super-duper-branch-images
     spec:
       containers:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -7,8 +7,6 @@ postsubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
-    labels:
-      artifacts: images
     name: branch-ci-super-duper-master-images
     spec:
       containers:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -7,8 +7,6 @@ postsubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
-    labels:
-      artifacts: images
     name: branch-ci-super-duper-release-3.11-images
     spec:
       containers:


### PR DESCRIPTION
Remove the 'artifacts: images' label, it has been replaced by other
constructs. Clarify what is legacy and what is not with regards to
namespace rules.

We are removing 'openshift/origin-v4.0' in favor of 'ocp/4.0' and
'ocp/4.X' in the future.

Prereq for openshift/release#2878