### PR TITLE
Only generate `--promote` jobs on those that have promotion config

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -382,11 +382,10 @@ func generateJobs(
 	}
 
 	if len(configSpec.Images) > 0 {
-		// Images that have explicit promotion config or follow the legacy defaulting rules for promotion
-		// should get a postsubmit promotion job.
+		// Images that have explicit promotion config should get promoted
 		promotionNamespace := extractPromotionNamespace(configSpec)
 		promotionName := extractPromotionName(configSpec)
-		promote := configSpec.PromotionConfiguration != nil || shouldBePromoted(repoInfo.branch, promotionNamespace, promotionName)
+		promote := configSpec.PromotionConfiguration != nil
 
 		// TODO: we should populate labels based on ci-operator characteristics
 		labels := map[string]string{}

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-master.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-master.yaml
@@ -12,6 +12,9 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
   tag: ''
+promotion:
+  namespace: ocp # will add --target [release:latest] to the promote job
+  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-release-3.11.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-release-3.11.yaml
@@ -12,6 +12,9 @@ tag_specification:
   name: origin-v3.11
   namespace: openshift
   tag: ''
+promotion:
+  namespace: openshift
+  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org


### PR DESCRIPTION
All jobs in openshift/release now have explicit promotion config.