### PR TITLE
Separate out promotion check

### DIFF
--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -1,0 +1,36 @@
+package promotion
+
+import (
+	cioperatorapi "github.com/openshift/ci-operator/pkg/api"
+)
+
+const (
+	okdPromotionNamespace = "openshift"
+	okd40Imagestream      = "origin-v4.0"
+	ocpPromotionNamespace = "ocp"
+)
+
+// PromotesOfficialImages determines if a configuration will result in official images
+// being promoted. This is a proxy for determining if a configuration contributes to
+// the release payload.
+func PromotesOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
+	promotionNamespace := extractPromotionNamespace(configSpec)
+	promotionName := extractPromotionName(configSpec)
+	return (promotionNamespace == okdPromotionNamespace && promotionName == okd40Imagestream) || promotionNamespace == ocpPromotionNamespace
+}
+
+func extractPromotionNamespace(configSpec *cioperatorapi.ReleaseBuildConfiguration) string {
+	if configSpec.PromotionConfiguration != nil && configSpec.PromotionConfiguration.Namespace != "" {
+		return configSpec.PromotionConfiguration.Namespace
+	}
+
+	return ""
+}
+
+func extractPromotionName(configSpec *cioperatorapi.ReleaseBuildConfiguration) string {
+	if configSpec.PromotionConfiguration != nil && configSpec.PromotionConfiguration.Name != "" {
+		return configSpec.PromotionConfiguration.Name
+	}
+
+	return ""
+}

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -33,7 +33,7 @@ func TestPromotesOfficialImages(t *testing.T) {
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
 					Namespace: "openshift",
-					Name: "origin-v4.0",
+					Name:      "origin-v4.0",
 				},
 			},
 			expected: true,
@@ -43,7 +43,7 @@ func TestPromotesOfficialImages(t *testing.T) {
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
 					Namespace: "openshift",
-					Name: "random",
+					Name:      "random",
 				},
 			},
 			expected: false,

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -1,0 +1,59 @@
+package promotion
+
+import (
+	"testing"
+
+	cioperatorapi "github.com/openshift/ci-operator/pkg/api"
+)
+
+func TestPromotesOfficialImages(t *testing.T) {
+	var testCases = []struct {
+		name       string
+		configSpec *cioperatorapi.ReleaseBuildConfiguration
+		expected   bool
+	}{
+		{
+			name: "config without promotion doesn't produce official images",
+			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "config explicitly promoting to ocp namespace produces official images",
+			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Namespace: "ocp",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "config explicitly promoting to okd release imagestream in okd namespace produces official images",
+			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Namespace: "openshift",
+					Name: "origin-v4.0",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "config explicitly promoting to random imagestream in okd namespace does not produce official images",
+			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Namespace: "openshift",
+					Name: "random",
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := PromotesOfficialImages(testCase.configSpec), testCase.expected; actual != expected {
+				t.Errorf("%s: did not identify official promotion correctly, expected %v got %v", testCase.name, expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We will need to be able to operate on configs that promote in many tools
related to branching, so this should live in its own package. I removed
the fallbacks to the release input tag step as we enforce in ci-operator
that people use explicit promotion stanzas now.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller 