### PR TITLE
Fix the failure messages in rehearse integration test

### DIFF
--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -97,11 +97,11 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("Failed to execute rehearsal jobs: %v", err)
 	}
 
-	if missing := rehearsed.Difference(toBeRehearsed); missing.Len() > 0 {
-		t.Fatalf("did not rehearse expected prowJobs: %v", missing.List())
-	}
-	if extra := toBeRehearsed.Difference(rehearsed); extra.Len() > 0 {
+	if extra := rehearsed.Difference(toBeRehearsed); extra.Len() > 0 {
 		t.Fatalf("found unexpectedly rehearsed prowJobs: %v", extra.List())
+	}
+	if missing := toBeRehearsed.Difference(rehearsed); missing.Len() > 0 {
+		t.Fatalf("did not rehearse expected prowJobs: %v", missing.List())
 	}
 }
 


### PR DESCRIPTION
The messages were swiched between detected failure cases:

```
rehearsed \ toBeRehearsed == extra
toBeRehearsed \ rehearsed == missing
```
/cc @stevekuznetsov @droslean @bbguimaraes 