### PR TITLE
Discover new/changed ci-operator configs

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -112,3 +112,19 @@ func OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi
 		return nil
 	})
 }
+
+type CompoundCiopConfig map[string]*cioperatorapi.ReleaseBuildConfiguration
+
+func (compound *CompoundCiopConfig) add(handledConfig *cioperatorapi.ReleaseBuildConfiguration, handledElements *FilePathElements) error {
+	(*compound)[handledElements.Filename] = handledConfig
+	return nil
+}
+
+func CompoundLoad(path string) (CompoundCiopConfig, error) {
+	config := CompoundCiopConfig{}
+	if err := OperateOnCIOperatorConfigDir(path, config.add); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -115,8 +115,8 @@ func OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi
 
 type CompoundCiopConfig map[string]*cioperatorapi.ReleaseBuildConfiguration
 
-func (compound *CompoundCiopConfig) add(handledConfig *cioperatorapi.ReleaseBuildConfiguration, handledElements *FilePathElements) error {
-	(*compound)[handledElements.Filename] = handledConfig
+func (compound CompoundCiopConfig) add(handledConfig *cioperatorapi.ReleaseBuildConfiguration, handledElements *FilePathElements) error {
+	compound[handledElements.Filename] = handledConfig
 	return nil
 }
 

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -1,6 +1,7 @@
 package diffs
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/getlantern/deepcopy"
@@ -82,7 +83,7 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 			actual := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
 			expected := tc.expected()
 
-			if !equality.Semantic.DeepEqual(expected, actual) {
+			if !reflect.DeepEqual(expected, actual) {
 				t.Errorf("Detected changed ci-operator config changes differ from expected:\n%s", diff.ObjectDiff(expected, actual))
 			}
 		})

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -11,11 +11,83 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
 
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	templateapi "github.com/openshift/api/template/v1"
+
+	cioperatorapi "github.com/openshift/ci-operator/pkg/api"
+
+	"github.com/openshift/ci-operator-prowgen/pkg/config"
 )
+
+func TestGetChangedCiopConfigs(t *testing.T) {
+	baseCiopConfig := cioperatorapi.ReleaseBuildConfiguration{
+		InputConfiguration: cioperatorapi.InputConfiguration{
+			ReleaseTagConfiguration: &cioperatorapi.ReleaseTagConfiguration{
+				Cluster:   "kluster",
+				Namespace: "namespace",
+				Tag:       "tag",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		configGenerator func() (before, after config.CompoundCiopConfig)
+		expected        func() config.CompoundCiopConfig
+	}{{
+		name: "no changes",
+		configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
+			before := config.CompoundCiopConfig{"org-repo-branch.yaml": &baseCiopConfig}
+			after := config.CompoundCiopConfig{"org-repo-branch.yaml": &baseCiopConfig}
+			return before, after
+		},
+		expected: func() config.CompoundCiopConfig { return config.CompoundCiopConfig{} },
+	}, {
+		name: "new config",
+		configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
+			before := config.CompoundCiopConfig{"org-repo-branch.yaml": &baseCiopConfig}
+			after := config.CompoundCiopConfig{
+				"org-repo-branch.yaml":         &baseCiopConfig,
+				"org-repo-another-branch.yaml": &baseCiopConfig,
+			}
+			return before, after
+		},
+		expected: func() config.CompoundCiopConfig {
+			return config.CompoundCiopConfig{"org-repo-another-branch.yaml": &baseCiopConfig}
+		},
+	}, {
+		name: "changed config",
+		configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
+			before := config.CompoundCiopConfig{"org-repo-branch.yaml": &baseCiopConfig}
+			afterConfig := cioperatorapi.ReleaseBuildConfiguration{}
+			deepcopy.Copy(&afterConfig, baseCiopConfig)
+			afterConfig.InputConfiguration.ReleaseTagConfiguration.Tag = "another-tag"
+			after := config.CompoundCiopConfig{"org-repo-branch.yaml": &afterConfig}
+			return before, after
+		},
+		expected: func() config.CompoundCiopConfig {
+			expected := cioperatorapi.ReleaseBuildConfiguration{}
+			deepcopy.Copy(&expected, baseCiopConfig)
+			expected.InputConfiguration.ReleaseTagConfiguration.Tag = "another-tag"
+			return config.CompoundCiopConfig{"org-repo-branch.yaml": &expected}
+		},
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			before, after := tc.configGenerator()
+			actual := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
+			expected := tc.expected()
+
+			if !equality.Semantic.DeepEqual(expected, actual) {
+				t.Errorf("Detected changed ci-operator config changes differ from expected:\n%s", diff.ObjectDiff(expected, actual))
+			}
+		})
+	}
+}
 
 func TestGetChangedPresubmits(t *testing.T) {
 	basePresubmit := []prowconfig.Presubmit{

--- a/test/pj-rehearse-integration/candidate/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
@@ -1,0 +1,28 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+- from: base
+  to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -1,0 +1,35 @@
+presubmits:
+  super/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ciop-cfg-change
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    name: pull-ci-super-duper-ciop-cfg-change-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --give-pr-author-access-to-namespace=true
+        - --target=[images]
+        - --target=[release:latest]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-ciop-cfg-change.yaml
+              name: ci-operator-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'

--- a/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
@@ -1,0 +1,26 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -1,0 +1,35 @@
+presubmits:
+  super/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ciop-cfg-change
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    name: pull-ci-super-duper-ciop-cfg-change-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --give-pr-author-access-to-namespace=true
+        - --target=[images]
+        - --target=[release:latest]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-ciop-cfg-change.yaml
+              name: ci-operator-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'


### PR DESCRIPTION
Needed to implement a little `CompoundConfig` that loads all available
configs to memory, so that the comparison fits into our "load all config
from master, then load all config from PR" process.

As in https://github.com/openshift/ci-operator-prowgen/pull/91, we only discover the differences and log them. The followups are:

1. Optimize config loading so that we only do the `git checkout master; git checkout pr` dance once
2. Ditch the lazy ci-operator config inliner and start using the in-memory configs
3. Find jobs that use the changed configs and consider them for rehearsals.

/cc @stevekuznetsov @bbguimaraes @droslean 