### PR TITLE
Add flag to derive JobSpec from local changes 

### DIFF
--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -29,8 +29,8 @@ type ReleaseRepoConfig struct {
 	Templates  CiTemplates
 }
 
-func getCurrentSHA(repoPath string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "HEAD")
+func revParse(repoPath string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"rev-parse"}, args...)...)
 	cmd.Dir = repoPath
 	sha, err := cmd.Output()
 	if err != nil {
@@ -85,7 +85,7 @@ func GetAllConfigs(releaseRepoPath string, logger *logrus.Entry) *ReleaseRepoCon
 // manipulations are propagated in the error return value. Errors occurred during the actual config loading are not
 // propagated, but the returned struct field will have a nil value in the appropriate field. The error is only logged.
 func GetAllConfigsFromSHA(releaseRepoPath, sha string, logger *logrus.Entry) (*ReleaseRepoConfig, error) {
-	currentSHA, err := getCurrentSHA(releaseRepoPath)
+	currentSHA, err := revParse(releaseRepoPath, "HEAD")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get SHA of current HEAD: %v", err)
 	}

--- a/test/pj-rehearse-integration/run.sh
+++ b/test/pj-rehearse-integration/run.sh
@@ -24,6 +24,8 @@ make_testing_repository() {
   mkdir "${FAKE_OPENSHIFT_RELEASE}"
   pushd "${FAKE_OPENSHIFT_RELEASE}" >/dev/null
   git init --quiet
+  git config --local user.name test
+  git config --local user.email test
   cp -R "${master_data}"/* .
   git add ci-operator cluster
   git commit -m "Master version of openshift/release" --quiet


### PR DESCRIPTION
/cc @droslean @petr-muller @stevekuznetsov

To be used in concert with the staging namespace for cases where we need to change more than the ProwJob. Only the manner in which we derive `JobSpec` is changed, so it should automatically pick up new additions (e.g. template tests) to the CI job.

Includes a few minor changes that didn't seem appropriate as separate PRs.