### PR TITLE
 Remove duplicate ci-operator config loading code 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -269,7 +269,7 @@
   branch = "master"
   name = "github.com/openshift/ci-operator"
   packages = ["pkg/api"]
-  revision = "1f0ee46080593c7955640a9385c1a1d00238306b"
+  revision = "3ae51bc3f5d8874342611325573ec77adee8835f"
 
 [[projects]]
   name = "github.com/openshift/client-go"

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -180,7 +180,7 @@ func main() {
 	loggers := rehearse.Loggers{Job: logger, Debug: debugLogger.WithField(prowgithub.PrLogField, prNumber)}
 
 	changedPresubmits := diffs.GetChangedPresubmits(prowConfig, prowPRConfig, logger)
-	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, o.candidatePath, prNumber, loggers, o.allowVolumes)
+	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPRConfig, prNumber, loggers, o.allowVolumes)
 	if len(rehearsals) == 0 {
 		logger.Info("no jobs to rehearse have been found")
 		os.Exit(0)

--- a/test/pj-rehearse-integration/expected_jobs.yaml
+++ b/test/pj-rehearse-integration/expected_jobs.yaml
@@ -53,26 +53,26 @@
                 name: origin-v4.0
                 namespace: openshift
                 tag: base
-            images:
-            - from: base
-              to: test-image
-            tag_specification:
-              cluster: https://api.ci.openshift.org
-              name: origin-v4.0
-              namespace: openshift
-              tag: ''
             build_root:
               image_stream_tag:
                 cluster: https://api.ci.openshift.org
-                namespace: openshift
                 name: release
+                namespace: openshift
                 tag: golang-1.10
+            canonical_go_repository: ""
+            images:
+            - from: base
+              to: test-image
             resources:
               '*':
                 limits:
                   cpu: 500Mi
                 requests:
                   cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -152,26 +152,26 @@
                 name: origin-v4.0
                 namespace: openshift
                 tag: base
-            images:
-            - from: base
-              to: test-image
-            tag_specification:
-              cluster: https://api.ci.openshift.org
-              name: origin-v4.0
-              namespace: openshift
-              tag: ''
             build_root:
               image_stream_tag:
                 cluster: https://api.ci.openshift.org
-                namespace: openshift
                 name: release
+                namespace: openshift
                 tag: golang-1.10
+            canonical_go_repository: ""
+            images:
+            - from: base
+              to: test-image
             resources:
               '*':
                 limits:
                   cpu: 500Mi
                 requests:
                   cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -251,26 +251,26 @@
                 name: origin-v4.0
                 namespace: openshift
                 tag: base
-            images:
-            - from: base
-              to: test-image
-            tag_specification:
-              cluster: https://api.ci.openshift.org
-              name: origin-v4.0
-              namespace: openshift
-              tag: ''
             build_root:
               image_stream_tag:
                 cluster: https://api.ci.openshift.org
-                namespace: openshift
                 name: release
+                namespace: openshift
                 tag: golang-1.10
+            canonical_go_repository: ""
+            images:
+            - from: base
+              to: test-image
             resources:
               '*':
                 limits:
                   cpu: 500Mi
                 requests:
                   cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -351,26 +351,26 @@
                 name: origin-v4.0
                 namespace: openshift
                 tag: base
-            images:
-            - from: base
-              to: test-image
-            tag_specification:
-              cluster: https://api.ci.openshift.org
-              name: origin-v4.0
-              namespace: openshift
-              tag: ''
             build_root:
               image_stream_tag:
                 cluster: https://api.ci.openshift.org
-                namespace: openshift
                 name: release
+                namespace: openshift
                 tag: golang-1.10
+            canonical_go_repository: ""
+            images:
+            - from: base
+              to: test-image
             resources:
               '*':
                 limits:
                   cpu: 500Mi
                 requests:
                   cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/vendor/github.com/openshift/ci-operator/CONFIGURATION.md
+++ b/vendor/github.com/openshift/ci-operator/CONFIGURATION.md
@@ -152,7 +152,9 @@ base_images:
 ```
 
 The key in this mapping is the name that can be used in `"from"` fields elsewhere
-in the configuration to refer to this image.
+in the configuration to refer to this image. If `tag_specification` is set, you
+may omit `cluster`, `namespace`, and `name` and they will be defaulted from the
+`tag_specification`.
 
 # `base_rpm_images`
 `base_rpm_images` are images that will have the RPMs that are built from the

--- a/vendor/github.com/openshift/ci-operator/cmd/ci-operator/main.go
+++ b/vendor/github.com/openshift/ci-operator/cmd/ci-operator/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/openshift/ci-operator/pkg/defaults"
+	"github.com/openshift/ci-operator/pkg/load"
 
 	coreapi "k8s.io/api/core/v1"
 	rbacapi "k8s.io/api/rbac/v1"
@@ -121,9 +122,9 @@ development workflow would use. The --override file will override fields
 defined in the config file, such as base images and the release tag configuration.
 
 After a successful build the --promote will tag each built image (in "images")
-to the image stream(s) identified by the "promotion" config, which defaults to
-the same image stream as the release configuration. You may add additional
-images to promote and their target names via the "additional_images" map.
+to the image stream(s) identified by the "promotion" config. You may add
+additional images to promote and their target names via the "additional_images"
+map.
 `
 
 func main() {
@@ -250,27 +251,11 @@ func (o *options) Validate() error {
 }
 
 func (o *options) Complete() error {
-	// Load the standard configuration from the path or env
-	var configSpec string
-	if len(o.configSpecPath) > 0 {
-		data, err := ioutil.ReadFile(o.configSpecPath)
-		if err != nil {
-			return fmt.Errorf("--config error: %v", err)
-		}
-		configSpec = string(data)
-	} else {
-		var ok bool
-		configSpec, ok = os.LookupEnv("CONFIG_SPEC")
-		if !ok || len(configSpec) == 0 {
-			return fmt.Errorf("CONFIG_SPEC environment variable is not set or empty and no --config file was set")
-		}
+	config, err := load.Config(o.configSpecPath)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %v", err)
 	}
-	if o.configSpec == nil {
-		o.configSpec = &api.ReleaseBuildConfiguration{}
-	}
-	if err := yaml.Unmarshal([]byte(configSpec), o.configSpec); err != nil {
-		return fmt.Errorf("invalid configuration: %v\nvalue:\n%s", err, string(configSpec))
-	}
+	o.configSpec = config
 
 	if err := o.configSpec.Validate(); err != nil {
 		return err
@@ -304,15 +289,18 @@ func (o *options) Complete() error {
 		job, _ := json.Marshal(o.jobSpec)
 		log.Printf("Resolved job spec:\n%s", string(job))
 	}
-	refs := o.jobSpec.Refs
-	if len(refs.Pulls) > 0 {
-		var pulls []string
-		for _, pull := range refs.Pulls {
-			pulls = append(pulls, fmt.Sprintf("#%d %s @%s", pull.Number, shorten(pull.SHA, 8), pull.Author))
-		}
-		log.Printf("Resolved source https://github.com/%s/%s to %s@%s, merging: %s", refs.Org, refs.Repo, refs.BaseRef, shorten(refs.BaseSHA, 8), strings.Join(pulls, ", "))
-	} else {
-		log.Printf("Resolved source https://github.com/%s/%s to %s@%s", refs.Org, refs.Repo, refs.BaseRef, shorten(refs.BaseSHA, 8))
+
+	var refs []api.Refs
+	if o.jobSpec.Refs != nil {
+		refs = append(refs, *o.jobSpec.Refs)
+	}
+	refs = append(refs, o.jobSpec.ExtraRefs...)
+
+	if len(refs) == 0 {
+		log.Printf("No source defined")
+	}
+	for _, ref := range refs {
+		log.Printf(summarizeRef(ref))
 	}
 
 	for _, path := range o.secretDirectories.values {
@@ -578,20 +566,22 @@ func (o *options) initializeNamespace() error {
 		if err != nil {
 			return fmt.Errorf("could not get RBAC client for cluster config: %v", err)
 		}
-		for _, pull := range o.jobSpec.Refs.Pulls {
-			log.Printf("Creating rolebinding for user %s in namespace %s", pull.Author, o.namespace)
-			if _, err := rbacClient.RoleBindings(o.namespace).Create(&rbacapi.RoleBinding{
-				ObjectMeta: meta.ObjectMeta{
-					Name:      "ci-op-author-access",
-					Namespace: o.namespace,
-				},
-				Subjects: []rbacapi.Subject{{Kind: "User", Name: pull.Author}},
-				RoleRef: rbacapi.RoleRef{
-					Kind: "ClusterRole",
-					Name: "admin",
-				},
-			}); err != nil && !kerrors.IsAlreadyExists(err) {
-				return fmt.Errorf("could not create role binding for: %v", err)
+		if refs := o.jobSpec.Refs; refs != nil {
+			for _, pull := range refs.Pulls {
+				log.Printf("Creating rolebinding for user %s in namespace %s", pull.Author, o.namespace)
+				if _, err := rbacClient.RoleBindings(o.namespace).Create(&rbacapi.RoleBinding{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      "ci-op-author-access",
+						Namespace: o.namespace,
+					},
+					Subjects: []rbacapi.Subject{{Kind: "User", Name: pull.Author}},
+					RoleRef: rbacapi.RoleRef{
+						Kind: "ClusterRole",
+						Name: "admin",
+					},
+				}); err != nil && !kerrors.IsAlreadyExists(err) {
+					return fmt.Errorf("could not create role binding for: %v", err)
+				}
 			}
 		}
 	}
@@ -739,9 +729,21 @@ func (o *options) writeMetadataJSON() error {
 
 	m := prowResultMetadata{}
 
-	if len(o.jobSpec.Refs.Repo) > 0 {
+	if o.jobSpec.Refs != nil {
 		m.Repo = fmt.Sprintf("%s/%s", o.jobSpec.Refs.Org, o.jobSpec.Refs.Repo)
 		m.Repos = map[string]string{m.Repo: o.jobSpec.Refs.String()}
+	}
+	if len(o.jobSpec.ExtraRefs) > 0 {
+		if m.Repos == nil {
+			m.Repos = make(map[string]string)
+		}
+		for _, ref := range o.jobSpec.ExtraRefs {
+			repo := fmt.Sprintf("%s/%s", ref.Org, ref.Repo)
+			if _, ok := m.Repos[repo]; ok {
+				continue
+			}
+			m.Repos[repo] = ref.String()
+		}
 	}
 
 	m.Pod = o.jobSpec.ProwJobID
@@ -795,6 +797,9 @@ func eventJobDescription(jobSpec *api.JobSpec, namespace string) string {
 	pulls := []string{}
 	authors := []string{}
 
+	if jobSpec.Refs == nil {
+		return fmt.Sprintf("Running job %s in namespace %s", jobSpec.Job, namespace)
+	}
 	if len(jobSpec.Refs.Pulls) == 1 {
 		pull := jobSpec.Refs.Pulls[0]
 		return fmt.Sprintf("Running job %s for PR https://github.com/%s/%s/pull/%d in namespace %s from author %s",
@@ -810,6 +815,9 @@ func eventJobDescription(jobSpec *api.JobSpec, namespace string) string {
 
 // jobDescription returns a string representing the job's description.
 func jobDescription(job *api.JobSpec, config *api.ReleaseBuildConfiguration) string {
+	if job.Refs == nil {
+		return fmt.Sprintf("%s", job.Job)
+	}
 	var links []string
 	for _, pull := range job.Refs.Pulls {
 		links = append(links, fmt.Sprintf("https://github.com/%s/%s/pull/%d - %s", job.Refs.Org, job.Refs.Repo, pull.Number, pull.Author))
@@ -839,7 +847,7 @@ func jobSpecFromGitRef(ref string) (*api.JobSpec, error) {
 		return nil, fmt.Errorf("ref '%s' does not point to any commit in '%s'", parts[1], parts[0])
 	}
 	log.Printf("Resolved %s to commit %s", ref, sha)
-	return &api.JobSpec{Type: api.PeriodicJob, Job: "dev", Refs: api.Refs{Org: prefix[0], Repo: prefix[1], BaseRef: parts[1], BaseSHA: sha}}, nil
+	return &api.JobSpec{Type: api.PeriodicJob, Job: "dev", Refs: &api.Refs{Org: prefix[0], Repo: prefix[1], BaseRef: parts[1], BaseSHA: sha}}, nil
 }
 
 func nodeNames(nodes []*api.StepNode) []string {
@@ -924,6 +932,17 @@ func shorten(value string, l int) string {
 		return value[:l]
 	}
 	return value
+}
+
+func summarizeRef(refs api.Refs) string {
+	if len(refs.Pulls) > 0 {
+		var pulls []string
+		for _, pull := range refs.Pulls {
+			pulls = append(pulls, fmt.Sprintf("#%d %s @%s", pull.Number, shorten(pull.SHA, 8), pull.Author))
+		}
+		return fmt.Sprintf("Resolved source https://github.com/%s/%s to %s@%s, merging: %s", refs.Org, refs.Repo, refs.BaseRef, shorten(refs.BaseSHA, 8), strings.Join(pulls, ", "))
+	}
+	return fmt.Sprintf("Resolved source https://github.com/%s/%s to %s@%s", refs.Org, refs.Repo, refs.BaseRef, shorten(refs.BaseSHA, 8))
 }
 
 func eventRecorder(kubeClient *coreclientset.CoreV1Client, namespace string) record.EventRecorder {

--- a/vendor/github.com/openshift/ci-operator/pkg/api/config.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/api/config.go
@@ -105,7 +105,7 @@ func validateTestStepConfiguration(fieldRoot string, input []TestStepConfigurati
 			validationErrors = append(validationErrors, fmt.Errorf("%s[%d].commands: is required", fieldRoot, num))
 		}
 
-		if len(test.Secret.Name) > 0 {
+		if test.Secret != nil {
 			// TODO: Move to upstream validation when vendoring is fixed
 			// currently checking against DNS RFC 1123 regexp
 			if ok := regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$").MatchString(test.Secret.Name); !ok {

--- a/vendor/github.com/openshift/ci-operator/pkg/api/config_test.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/api/config_test.go
@@ -75,7 +75,7 @@ func TestValidateTests(t *testing.T) {
 			id: "test without `commands`",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                         "test",
 					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 			},
@@ -142,7 +142,7 @@ func TestValidateTests(t *testing.T) {
 			id: "invalid cluster profile",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                                       "test",
 					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
 				},
 			},
@@ -192,9 +192,9 @@ func TestValidateTests(t *testing.T) {
 			id: "invalid secret mountPath",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                                       "test",
 					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
-					Secret: Secret{
+					Secret: &Secret{
 						Name:      "secret",
 						MountPath: "/path/to/secret:exec",
 					},
@@ -206,9 +206,9 @@ func TestValidateTests(t *testing.T) {
 			id: "invalid secret name",
 			tests: []TestStepConfiguration{
 				{
-					As: "test",
+					As:                                       "test",
 					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{},
-					Secret: Secret{
+					Secret: &Secret{
 						Name:      "secret_test",
 						MountPath: "/path/to/secret:exec",
 					},
@@ -223,7 +223,7 @@ func TestValidateTests(t *testing.T) {
 					As:                         "unit",
 					Commands:                   "commands",
 					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
-					Secret: Secret{
+					Secret: &Secret{
 						Name: "secret",
 					},
 				},
@@ -237,7 +237,7 @@ func TestValidateTests(t *testing.T) {
 					As:                         "unit",
 					Commands:                   "commands",
 					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
-					Secret: Secret{
+					Secret: &Secret{
 						Name:      "secret",
 						MountPath: "/path/to/secret",
 					},
@@ -252,7 +252,7 @@ func TestValidateTests(t *testing.T) {
 					As:                         "unit",
 					Commands:                   "commands",
 					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
-					Secret: Secret{
+					Secret: &Secret{
 						Name:      "secret",
 						MountPath: "path/to/secret",
 					},

--- a/vendor/github.com/openshift/ci-operator/pkg/api/job_spec.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/api/job_spec.go
@@ -19,7 +19,8 @@ type JobSpec struct {
 	BuildId   string      `json:"buildid,omitempty"`
 	ProwJobID string      `json:"prowjobid,omitempty"`
 
-	Refs Refs `json:"refs,omitempty"`
+	Refs      *Refs  `json:"refs,omitempty"`
+	ExtraRefs []Refs `json:"extra_refs,omitempty"`
 
 	// rawSpec is the serialized form of the Spec
 	rawSpec string

--- a/vendor/github.com/openshift/ci-operator/pkg/api/types.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/api/types.go
@@ -142,13 +142,13 @@ type ImageStreamTagReference struct {
 	// referenced cluster must support anonymous access to retrieve
 	// image streams, image stream tags, and image stream images in
 	// the provided namespace.
-	Cluster   string `json:"cluster"`
+	Cluster   string `json:"cluster,omitempty"`
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	Tag       string `json:"tag"`
 
 	// As is an optional string to use as the intermediate name for this reference.
-	As string `json:"as"`
+	As string `json:"as,omitempty"`
 }
 
 // ReleaseTagConfiguration describes how a release is
@@ -163,7 +163,7 @@ type ReleaseTagConfiguration struct {
 	// referenced cluster must support anonymous access to retrieve
 	// image streams, image stream tags, and image stream images in
 	// the provided namespace.
-	Cluster string `json:"cluster"`
+	Cluster string `json:"cluster,omitempty"`
 
 	// Namespace identifies the namespace from which
 	// all release artifacts not built in the current
@@ -177,17 +177,17 @@ type ReleaseTagConfiguration struct {
 
 	// Tag is the ImageStreamTag tagged in for each
 	// ImageStream in the above Namespace.
-	Tag string `json:"tag"`
+	Tag string `json:"tag,omitempty"`
 
 	// NamePrefix is prepended to the final output image name
 	// if specified.
-	NamePrefix string `json:"name_prefix"`
+	NamePrefix string `json:"name_prefix,omitempty"`
 
 	// TagOverrides is map of ImageStream name to
 	// tag, allowing for specific components in the
 	// above namespace to be tagged in at a different
 	// level than the rest.
-	TagOverrides map[string]string `json:"tag_overrides"`
+	TagOverrides map[string]string `json:"tag_overrides,omitempty"`
 }
 
 // PromotionConfiguration describes where images created by this
@@ -205,24 +205,24 @@ type PromotionConfiguration struct {
 
 	// Tag is the ImageStreamTag tagged in for each
 	// build image's ImageStream.
-	Tag string `json:"tag"`
+	Tag string `json:"tag,omitempty"`
 
 	// NamePrefix is prepended to the final output image name
 	// if specified.
-	NamePrefix string `json:"name_prefix"`
+	NamePrefix string `json:"name_prefix,omitempty"`
 
 	// ExcludedImages are image names that will not be promoted.
 	// Exclusions are made before additional_images are included.
 	// Use exclusions when you want to build images for testing
 	// but not promote them afterwards.
-	ExcludedImages []string `json:"excluded_images"`
+	ExcludedImages []string `json:"excluded_images,omitempty"`
 
 	// AdditionalImages is a mapping of images to promote. The
 	// images will be taken from the pipeline image stream. The
 	// key is the name to promote as and the value is the source
 	// name. If you specify a tag that does not exist as the source
 	// the destination tag will not be created.
-	AdditionalImages map[string]string `json:"additional_images"`
+	AdditionalImages map[string]string `json:"additional_images,omitempty"`
 }
 
 // StepConfiguration holds one step configuration.
@@ -286,11 +286,11 @@ type TestStepConfiguration struct {
 	// ArtifactDir is an optional directory that contains the
 	// artifacts to upload. If unset, this will default under
 	// the repository root to _output/local/artifacts.
-	ArtifactDir string `json:"artifact_dir"`
+	ArtifactDir string `json:"artifact_dir,omitempty"`
 
 	// Secret is an optional secret object which
 	// will be mounted inside the test container.
-	Secret Secret `json:"secret,omitempty"`
+	Secret *Secret `json:"secret,omitempty"`
 
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                      *ContainerTestConfiguration                      `json:"container,omitempty"`
@@ -330,7 +330,7 @@ type ContainerTestConfiguration struct {
 	From PipelineImageStreamTagReference `json:"from"`
 	// MemoryBackedVolume mounts a volume of the specified size into
 	// the container at /tmp/volume.
-	MemoryBackedVolume *MemoryBackedVolume `json:"memory_backed_volume"`
+	MemoryBackedVolume *MemoryBackedVolume `json:"memory_backed_volume,omitempty"`
 }
 
 // ClusterProfile is the name of a set of input variables
@@ -456,23 +456,23 @@ type ProjectDirectoryImageBuildStepConfiguration struct {
 	// Optional means the build step is not built, published, or
 	// promoted unless explicitly targeted. Use for builds which
 	// are invoked only when testing certain parts of the repo.
-	Optional bool `json:"optional"`
+	Optional bool `json:"optional,omitempty"`
 }
 
 // ProjectDirectoryImageBuildInputs holds inputs for an image build from the repo under test
 type ProjectDirectoryImageBuildInputs struct {
 	// ContextDir is the directory in the project
 	// from which this build should be run.
-	ContextDir string `json:"context_dir"`
+	ContextDir string `json:"context_dir,omitempty"`
 
 	// DockerfilePath is the path to a Dockerfile in the
 	// project to run relative to the context_dir.
-	DockerfilePath string `json:"dockerfile_path"`
+	DockerfilePath string `json:"dockerfile_path,omitempty"`
 
 	// Inputs is a map of tag reference name to image input changes
 	// that will populate the build context for the Dockerfile or
 	// alter the input image for a multi-stage build.
-	Inputs map[string]ImageBuildInputs `json:"inputs"`
+	Inputs map[string]ImageBuildInputs `json:"inputs,omitempty"`
 }
 
 // ImageBuildInputs is a subset of the v1 OpenShift Build API object
@@ -486,7 +486,7 @@ type ImageBuildInputs struct {
 	// if the Dockerfile defines FROM nginx:latest AS base, specifying
 	// either "nginx:latest" or "base" in this array will replace that
 	// image with the pipeline input.
-	As []string `json:"as"`
+	As []string `json:"as,omitempty"`
 }
 
 // ImageSourcePath maps a path in the source image into a destination

--- a/vendor/github.com/openshift/ci-operator/pkg/load/load.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/load/load.go
@@ -1,0 +1,34 @@
+package load
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/openshift/ci-operator/pkg/api"
+)
+
+func Config(path string) (*api.ReleaseBuildConfiguration, error) {
+	// Load the standard configuration from the path or env
+	var raw string
+	if len(path) > 0 {
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("--config error: %v", err)
+		}
+		raw = string(data)
+	} else {
+		var ok bool
+		raw, ok = os.LookupEnv("CONFIG_SPEC")
+		if !ok || len(raw) == 0 {
+			return nil, fmt.Errorf("CONFIG_SPEC environment variable is not set or empty and no config file was set")
+		}
+	}
+	configSpec := &api.ReleaseBuildConfiguration{}
+	if err := yaml.Unmarshal([]byte(raw), configSpec); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %v\nvalue:\n%s", err, string(raw))
+	}
+	return configSpec, nil
+}

--- a/vendor/github.com/openshift/ci-operator/pkg/load/load_test.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/load/load_test.go
@@ -1,0 +1,561 @@
+package load
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/ci-operator/pkg/api"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+const rawConfig = `tag_specification:
+  name: '4.0'
+  namespace: ocp
+promotion:
+  name: '4.0'
+  namespace: ocp
+  additional_images:
+    artifacts: artifacts
+  excluded_images:
+  - machine-os-content
+base_images:
+  base:
+    name: '4.0'
+    namespace: ocp
+    tag: base
+  base-machine:
+    cluster: https://api.ci.openshift.org
+    name: fedora
+    namespace: openshift
+    tag: '29'
+  machine-os-content-base:
+    name: '4.0'
+    namespace: ocp
+    tag: machine-os-content
+binary_build_commands: make build WHAT='cmd/hypershift vendor/k8s.io/kubernetes/cmd/hyperkube'
+canonical_go_repository: github.com/openshift/origin
+images:
+- dockerfile_path: images/template-service-broker/Dockerfile.rhel
+  from: base
+  to: template-service-broker
+  inputs:
+    bin:
+      as:
+      - builder
+- dockerfile_path: images/cli/Dockerfile.rhel
+  from: base
+  to: cli
+  inputs:
+    bin:
+      as:
+      - builder
+- dockerfile_path: images/hypershift/Dockerfile.rhel
+  from: base
+  to: hypershift
+  inputs:
+    bin:
+      as:
+      - builder
+- dockerfile_path: images/hyperkube/Dockerfile.rhel
+  from: base
+  to: hyperkube
+  inputs:
+    bin:
+      as:
+      - builder
+- dockerfile_path: images/tests/Dockerfile.rhel
+  from: cli
+  to: tests
+  inputs:
+    bin:
+      as:
+      - builder
+- context_dir: images/deployer/
+  dockerfile_path: Dockerfile.rhel
+  from: cli
+  to: deployer
+- context_dir: images/recycler/
+  dockerfile_path: Dockerfile.rhel
+  from: cli
+  to: recycler
+- dockerfile_path: images/sdn/Dockerfile.rhel
+  from: base
+  to: node # TODO: SDN
+  inputs:
+    bin:
+      as:
+      - builder
+- context_dir: images/os/
+  from: base
+  inputs:
+    base-machine-with-rpms:
+      as:
+      - builder
+    machine-os-content-base:
+      as:
+      -  registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content
+  to: machine-os-content
+raw_steps:
+- pipeline_image_cache_step:
+    commands: mkdir -p _output/local/releases; touch _output/local/releases/CHECKSUM;
+      echo $'FROM bin AS bin\nFROM rpms AS rpms\nFROM centos:7\nCOPY --from=bin /go/src/github.com/openshift/origin/_output/local/releases
+      /srv/zips/\nCOPY --from=rpms /go/src/github.com/openshift/origin/_output/local/releases/rpms/*
+      /srv/repo/' > _output/local/releases/Dockerfile; make build-cross
+    from: bin
+    to: bin-cross
+- project_directory_image_build_step:
+    from: base
+    inputs:
+      bin-cross:
+        as:
+        - bin
+        paths:
+        - destination_dir: .
+          source_path: /go/src/github.com/openshift/origin/_output/local/releases/Dockerfile
+      rpms:
+        as:
+        - rpms
+      src: {}
+    optional: true
+    to: artifacts
+- output_image_tag_step:
+    from: artifacts
+    optional: true
+    to:
+      name: stable
+      tag: artifacts
+- rpm_image_injection_step:
+    from: base
+    to: base-with-rpms
+- rpm_image_injection_step:
+    from: base-machine
+    to: base-machine-with-rpms
+resources:
+  '*':
+    limits:
+      memory: 6Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  bin:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: '3'
+      memory: 8Gi
+  bin-cross:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: '3'
+      memory: 8Gi
+  cmd:
+    limits:
+      memory: 11Gi
+    requests:
+      cpu: '3'
+      memory: 8Gi
+  integration:
+    limits:
+      memory: 18Gi
+    requests:
+      cpu: '3'
+      memory: 14Gi
+  rpms:
+    limits:
+      memory: 10Gi
+    requests:
+      cpu: '3'
+      memory: 8Gi
+  unit:
+    limits:
+      memory: 14Gi
+    requests:
+      cpu: '3'
+      memory: 11Gi
+  verify:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: '3'
+      memory: 8Gi
+rpm_build_commands: make build-rpms
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: src-cache-origin
+    namespace: ci
+    tag: master
+tests:
+- artifact_dir: /tmp/artifacts
+  as: cmd
+  commands: TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1
+    KUBERNETES_SERVICE_HOST= make test-cmd -k
+  container:
+    from: bin
+    memory_backed_volume:
+      size: 4Gi
+- artifact_dir: /tmp/artifacts
+  as: unit
+  commands: ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST=
+    hack/test-go.sh
+  container:
+    from: src
+- artifact_dir: /tmp/artifacts
+  as: integration
+  commands: GOMAXPROCS=8 TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1
+    KUBERNETES_SERVICE_HOST= make test-integration
+  container:
+    from: bin
+    memory_backed_volume:
+      size: 4Gi
+- artifact_dir: /tmp/artifacts
+  as: verify
+  commands: ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make
+    verify -k
+  container:
+    from: bin
+- as: e2e-aws
+  commands: TEST_SUITE=openshift/conformance/parallel run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: e2e-aws-all
+  commands: TEST_SUITE=openshift/conformance run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: e2e-aws-builds
+  commands: TEST_SUITE=openshift/build run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: e2e-aws-image-ecosystem
+  commands: TEST_SUITE=openshift/image-ecosystem run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: e2e-aws-image-registry
+  commands: TEST_SUITE=openshift/image-registry run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: e2e-aws-serial
+  commands: TEST_SUITE=openshift/conformance/serial run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: e2e-conformance-k8s
+  commands: test/extended/conformance-k8s.sh
+  openshift_installer_src:
+    cluster_profile: aws
+- as: launch-aws
+  commands: sleep 7200 & wait
+  openshift_installer:
+    cluster_profile: aws
+`
+
+var parsedConfig = &api.ReleaseBuildConfiguration{
+	InputConfiguration: api.InputConfiguration{
+		BaseImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Name:      "4.0",
+				Namespace: "ocp",
+				Tag:       "base",
+			},
+			"base-machine": {
+				Cluster:   "https://api.ci.openshift.org",
+				Name:      "fedora",
+				Namespace: "openshift",
+				Tag:       "29",
+			},
+			"machine-os-content-base": {
+				Name:      "4.0",
+				Namespace: "ocp",
+				Tag:       "machine-os-content",
+			},
+		},
+		BuildRootImage: &api.BuildRootImageConfiguration{
+			ImageStreamTagReference: &api.ImageStreamTagReference{
+				Cluster:   "https://api.ci.openshift.org",
+				Name:      "src-cache-origin",
+				Namespace: "ci",
+				Tag:       "master",
+			},
+		},
+		ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+			Name:      "4.0",
+			Namespace: "ocp",
+		},
+	},
+	BinaryBuildCommands:     `make build WHAT='cmd/hypershift vendor/k8s.io/kubernetes/cmd/hyperkube'`,
+	TestBinaryBuildCommands: "",
+	RpmBuildCommands:        "make build-rpms",
+	RpmBuildLocation:        "",
+	CanonicalGoRepository:   "github.com/openshift/origin",
+	Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+		From: "base",
+		To:   "template-service-broker",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "images/template-service-broker/Dockerfile.rhel",
+			Inputs:         map[string]api.ImageBuildInputs{"bin": {As: []string{"builder"}}},
+		},
+	}, {
+		From: "base",
+		To:   "cli",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "images/cli/Dockerfile.rhel",
+			Inputs:         map[string]api.ImageBuildInputs{"bin": {As: []string{"builder"}}},
+		},
+	}, {
+		From: "base",
+		To:   "hypershift",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "images/hypershift/Dockerfile.rhel",
+			Inputs:         map[string]api.ImageBuildInputs{"bin": {As: []string{"builder"}}},
+		},
+	}, {
+		From: "base",
+		To:   "hyperkube",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "images/hyperkube/Dockerfile.rhel",
+			Inputs:         map[string]api.ImageBuildInputs{"bin": {As: []string{"builder"}}},
+		},
+	}, {
+		From: "cli",
+		To:   "tests",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "images/tests/Dockerfile.rhel",
+			Inputs:         map[string]api.ImageBuildInputs{"bin": {As: []string{"builder"}}},
+		},
+	}, {
+		From: "cli",
+		To:   "deployer",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "Dockerfile.rhel",
+			ContextDir:     "images/deployer/",
+		},
+	}, {
+		From: "cli",
+		To:   "recycler",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "Dockerfile.rhel",
+			ContextDir:     "images/recycler/",
+		},
+	}, {
+		From: "base",
+		To:   "node",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			DockerfilePath: "images/sdn/Dockerfile.rhel",
+			Inputs:         map[string]api.ImageBuildInputs{"bin": {As: []string{"builder"}}},
+		},
+	}, {
+		From: "base",
+		To:   "machine-os-content",
+		ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+			ContextDir: "images/os/",
+			Inputs: map[string]api.ImageBuildInputs{
+				"base-machine-with-rpms":  {As: []string{"builder"}},
+				"machine-os-content-base": {As: []string{"registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content"}},
+			},
+		},
+	}},
+	RawSteps: []api.StepConfiguration{{
+		PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+			From:     "bin",
+			To:       "bin-cross",
+			Commands: `mkdir -p _output/local/releases; touch _output/local/releases/CHECKSUM; echo $'FROM bin AS bin\nFROM rpms AS rpms\nFROM centos:7\nCOPY --from=bin /go/src/github.com/openshift/origin/_output/local/releases /srv/zips/\nCOPY --from=rpms /go/src/github.com/openshift/origin/_output/local/releases/rpms/* /srv/repo/' > _output/local/releases/Dockerfile; make build-cross`,
+		},
+	}, {
+		ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
+			From: "base",
+			To:   "artifacts",
+			ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+				Inputs: map[string]api.ImageBuildInputs{
+					"bin-cross": {As: []string{"bin"}, Paths: []api.ImageSourcePath{{DestinationDir: ".", SourcePath: "/go/src/github.com/openshift/origin/_output/local/releases/Dockerfile"}}},
+					"rpms":      {As: []string{"rpms"}},
+					"src":       {},
+				},
+			},
+			Optional: true,
+		},
+	}, {
+		OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
+			From:     "artifacts",
+			To:       api.ImageStreamTagReference{Name: "stable", Tag: "artifacts"},
+			Optional: true,
+		},
+	}, {
+		RPMImageInjectionStepConfiguration: &api.RPMImageInjectionStepConfiguration{
+			From: "base",
+			To:   "base-with-rpms",
+		},
+	}, {
+		RPMImageInjectionStepConfiguration: &api.RPMImageInjectionStepConfiguration{
+			From: "base-machine",
+			To:   "base-machine-with-rpms",
+		},
+	}},
+	PromotionConfiguration: &api.PromotionConfiguration{
+		Namespace:        "ocp",
+		Name:             "4.0",
+		AdditionalImages: map[string]string{"artifacts": "artifacts"},
+		ExcludedImages:   []string{"machine-os-content"},
+	},
+	Resources: map[string]api.ResourceRequirements{
+		"*":           {Limits: map[string]string{"memory": "6Gi"}, Requests: map[string]string{"cpu": "100m", "memory": "200Mi"}},
+		"bin":         {Limits: map[string]string{"memory": "12Gi"}, Requests: map[string]string{"cpu": "3", "memory": "8Gi"}},
+		"bin-cross":   {Limits: map[string]string{"memory": "12Gi"}, Requests: map[string]string{"cpu": "3", "memory": "8Gi"}},
+		"cmd":         {Limits: map[string]string{"memory": "11Gi"}, Requests: map[string]string{"cpu": "3", "memory": "8Gi"}},
+		"integration": {Limits: map[string]string{"memory": "18Gi"}, Requests: map[string]string{"cpu": "3", "memory": "14Gi"}},
+		"rpms":        {Limits: map[string]string{"memory": "10Gi"}, Requests: map[string]string{"cpu": "3", "memory": "8Gi"}},
+		"unit":        {Limits: map[string]string{"memory": "14Gi"}, Requests: map[string]string{"cpu": "3", "memory": "11Gi"}},
+		"verify":      {Limits: map[string]string{"memory": "12Gi"}, Requests: map[string]string{"cpu": "3", "memory": "8Gi"}},
+	},
+	Tests: []api.TestStepConfiguration{{
+		As:          "cmd",
+		ArtifactDir: "/tmp/artifacts",
+		Commands:    `TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make test-cmd -k`,
+		ContainerTestConfiguration: &api.ContainerTestConfiguration{
+			From: "bin",
+			MemoryBackedVolume: &api.MemoryBackedVolume{
+				Size: "4Gi",
+			},
+		},
+	}, {
+		As:          "unit",
+		ArtifactDir: "/tmp/artifacts",
+		Commands:    `ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh`,
+		ContainerTestConfiguration: &api.ContainerTestConfiguration{
+			From: "src",
+		},
+	}, {
+		As:          "integration",
+		ArtifactDir: "/tmp/artifacts",
+		Commands:    `GOMAXPROCS=8 TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make test-integration`,
+		ContainerTestConfiguration: &api.ContainerTestConfiguration{
+			From: "bin",
+			MemoryBackedVolume: &api.MemoryBackedVolume{
+				Size: "4Gi",
+			},
+		},
+	}, {
+		As:          "verify",
+		ArtifactDir: "/tmp/artifacts",
+		Commands:    `ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make verify -k`,
+		ContainerTestConfiguration: &api.ContainerTestConfiguration{
+			From: "bin",
+		},
+	}, {
+		As:       "e2e-aws",
+		Commands: `TEST_SUITE=openshift/conformance/parallel run-tests`,
+		OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "e2e-aws-all",
+		Commands: `TEST_SUITE=openshift/conformance run-tests`,
+		OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "e2e-aws-builds",
+		Commands: `TEST_SUITE=openshift/build run-tests`,
+		OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "e2e-aws-image-ecosystem",
+		Commands: `TEST_SUITE=openshift/image-ecosystem run-tests`,
+		OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "e2e-aws-image-registry",
+		Commands: `TEST_SUITE=openshift/image-registry run-tests`,
+		OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "e2e-aws-serial",
+		Commands: `TEST_SUITE=openshift/conformance/serial run-tests`,
+		OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "e2e-conformance-k8s",
+		Commands: `test/extended/conformance-k8s.sh`,
+		OpenshiftInstallerSrcClusterTestConfiguration: &api.OpenshiftInstallerSrcClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "launch-aws",
+		Commands: `sleep 7200 & wait`,
+		OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}},
+}
+
+func TestConfig(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		asFile        bool
+		asEnv         bool
+		expected      *api.ReleaseBuildConfiguration
+		expectedError bool
+	}{
+		{
+			name:          "loading config from file works",
+			asFile:        true,
+			expected:      parsedConfig,
+			expectedError: false,
+		},
+		{
+			name:          "loading config from env works",
+			asEnv:         true,
+			expected:      parsedConfig,
+			expectedError: false,
+		},
+		{
+			name:          "no file or env fails to load config",
+			asEnv:         true,
+			expected:      parsedConfig,
+			expectedError: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var path string
+			if testCase.asFile {
+				temp, err := ioutil.TempFile("", "")
+				if err != nil {
+					t.Fatalf("%s: failed to create temp config file: %v", testCase.name, err)
+				}
+				defer func() {
+					if err := os.Remove(temp.Name()); err != nil {
+						t.Fatalf("%s: failed to remove temp config file: %v", testCase.name, err)
+					}
+				}()
+				path = temp.Name()
+
+				if err := ioutil.WriteFile(path, []byte(rawConfig), 0664); err != nil {
+					t.Fatalf("%s: failed to populate temp config file: %v", testCase.name, err)
+				}
+			}
+			if testCase.asEnv {
+				if err := os.Setenv("CONFIG_SPEC", rawConfig); err != nil {
+					t.Fatalf("%s: failed to populate env var: %v", testCase.name, err)
+				}
+			}
+			config, err := Config(path)
+			if err == nil && testCase.expectedError {
+				t.Errorf("%s: expected an error, but got none", testCase.name)
+			}
+			if err != nil && !testCase.expectedError {
+				t.Errorf("%s: expected no error, but got one: %v", testCase.name, err)
+			}
+			if actual, expected := config, testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: didn't get correct config: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+
+		})
+	}
+}

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/git_source.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/git_source.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"log"
 
 	buildapi "github.com/openshift/api/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
@@ -23,6 +24,10 @@ func (s *gitSourceStep) Inputs(ctx context.Context, dry bool) (api.InputDefiniti
 }
 
 func (s *gitSourceStep) Run(ctx context.Context, dry bool) error {
+	if s.jobSpec.Refs == nil {
+		log.Printf("Nothing to build source image from, no refs")
+		return nil
+	}
 	return handleBuild(s.buildClient, buildFromSource(s.jobSpec, "", api.PipelineImageStreamTagReferenceRoot, buildapi.BuildSource{
 		Type:       buildapi.BuildSourceGit,
 		ContextDir: s.config.ContextDir,

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/pod.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/pod.go
@@ -27,7 +27,7 @@ type PodStepConfiguration struct {
 	Commands           string
 	ArtifactDir        string
 	ServiceAccountName string
-	Secret             api.Secret
+	Secret             *api.Secret
 	MemoryBackedVolume *api.MemoryBackedVolume
 }
 
@@ -213,7 +213,7 @@ func (s *podStep) generatePodForStep(image string, containerResources coreapi.Re
 		},
 	}
 
-	if s.config.Secret.Name != "" {
+	if s.config.Secret != nil {
 		pod.Spec.Containers[0].VolumeMounts = getSecretVolumeMountFromSecret(s.config.Secret.MountPath)
 		pod.Spec.Volumes = getVolumeFromSecret(s.config.Secret.Name)
 	}

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/pod_test.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/pod_test.go
@@ -3,7 +3,7 @@ package steps
 import (
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,10 +192,8 @@ func TestGetPodObjectMounts(t *testing.T) {
 		expectedVolumeConfig *v1.Pod
 	}{
 		{
-			name: "no secret name results in no mounted secrets",
-			podStep: func(expectedPodStepTemplate *podStep) {
-				expectedPodStepTemplate.config.Secret.Name = ""
-			},
+			name:    "no secret results in no mounted secrets",
+			podStep: func(expectedPodStepTemplate *podStep) {},
 			expectedVolumeConfig: &v1.Pod{
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -210,7 +208,7 @@ func TestGetPodObjectMounts(t *testing.T) {
 		{
 			name: "with secret name results in secret mounted with default path",
 			podStep: func(expectedPodStepTemplate *podStep) {
-				expectedPodStepTemplate.config.Secret.Name = testSecretName
+				expectedPodStepTemplate.config.Secret = &api.Secret{Name: testSecretName}
 			},
 			expectedVolumeConfig: &v1.Pod{
 				Spec: v1.PodSpec{
@@ -241,8 +239,10 @@ func TestGetPodObjectMounts(t *testing.T) {
 		{
 			name: "with secret name and path results in mounted secret with custom path",
 			podStep: func(expectedPodStepTemplate *podStep) {
-				expectedPodStepTemplate.config.Secret.Name = testSecretName
-				expectedPodStepTemplate.config.Secret.MountPath = "/usr/local/secrets"
+				expectedPodStepTemplate.config.Secret = &api.Secret{
+					Name:      testSecretName,
+					MountPath: "/usr/local/secrets",
+				}
 			},
 			expectedVolumeConfig: &v1.Pod{
 				Spec: v1.PodSpec{

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/project_image.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/project_image.go
@@ -66,16 +66,18 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) erro
 	} {
 		labels[key] = ""
 	}
-	if len(s.jobSpec.Refs.Pulls) == 0 {
-		labels["vcs-type"] = "git"
-		labels["vcs-ref"] = s.jobSpec.Refs.BaseSHA
-		labels["io.openshift.build.commit.id"] = s.jobSpec.Refs.BaseSHA
-		labels["io.openshift.build.commit.ref"] = s.jobSpec.Refs.BaseRef
-		if len(s.jobSpec.Refs.Org) > 0 && len(s.jobSpec.Refs.Repo) > 0 {
-			labels["vcs-url"] = fmt.Sprintf("https://github.com/%s/%s", s.jobSpec.Refs.Org, s.jobSpec.Refs.Repo)
+	if refs := s.jobSpec.Refs; refs != nil {
+		if len(refs.Pulls) == 0 {
+			labels["vcs-type"] = "git"
+			labels["vcs-ref"] = refs.BaseSHA
+			labels["io.openshift.build.commit.id"] = refs.BaseSHA
+			labels["io.openshift.build.commit.ref"] = refs.BaseRef
+			labels["vcs-url"] = fmt.Sprintf("https://github.com/%s/%s", refs.Org, refs.Repo)
 			labels["io.openshift.build.source-location"] = labels["vcs-url"]
+			labels["io.openshift.build.source-context-dir"] = s.config.ContextDir
 		}
-		labels["io.openshift.build.source-context-dir"] = s.config.ContextDir
+		// TODO: we should consider setting enough info for a caller to reconstruct pulls to support
+		// oc adm release info tooling
 	}
 
 	images := buildInputsFromStep(s.config.Inputs)

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/rpm_server.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/rpm_server.go
@@ -383,10 +383,13 @@ func (s *rpmServerStep) rpmRepoURL() (string, error) {
 }
 
 func (s *rpmServerStep) Provides() (api.ParameterMap, api.StepLink) {
-	rpmByOrgAndRepo := strings.Replace(fmt.Sprintf("RPM_REPO_%s_%s", strings.ToUpper(s.jobSpec.Refs.Org), strings.ToUpper(s.jobSpec.Refs.Repo)), "-", "_", -1)
-	return api.ParameterMap{
-		rpmByOrgAndRepo: s.rpmRepoURL,
-	}, api.RPMRepoLink()
+	if s.jobSpec.Refs != nil {
+		rpmByOrgAndRepo := strings.Replace(fmt.Sprintf("RPM_REPO_%s_%s", strings.ToUpper(s.jobSpec.Refs.Org), strings.ToUpper(s.jobSpec.Refs.Repo)), "-", "_", -1)
+		return api.ParameterMap{
+			rpmByOrgAndRepo: s.rpmRepoURL,
+		}, api.RPMRepoLink()
+	}
+	return nil, nil
 }
 
 func (s *rpmServerStep) Name() string { return "[serve:rpms]" }

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/run.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/run.go
@@ -45,6 +45,7 @@ func Run(ctx context.Context, graph []*api.StepNode, dry bool) (*junit.TestSuite
 	for {
 		select {
 		case <-ctxDone:
+			errors = append(errors, fmt.Errorf("execution cancelled"))
 			suite.Duration = time.Now().Sub(start).Seconds()
 			return suites, aggregateError(errors)
 		case out := <-results:

--- a/vendor/github.com/openshift/ci-operator/pkg/steps/source.go
+++ b/vendor/github.com/openshift/ci-operator/pkg/steps/source.go
@@ -97,14 +97,22 @@ func (s *sourceStep) Run(ctx context.Context, dry bool) error {
 		s.resources,
 	)
 
-	refs := s.jobSpec.Refs
-	refs.PathAlias = s.config.PathAlias
+	var refs []interface{}
+	// periodic jobs may have no refs to clone
+	if s.jobSpec.Refs != nil {
+		ref := s.jobSpec.Refs
+		ref.PathAlias = s.config.PathAlias
+		refs = append(refs, ref)
+	}
+	for _, ref := range s.jobSpec.ExtraRefs {
+		refs = append(refs, ref)
+	}
 	optionsSpec := map[string]interface{}{
 		"src_root":       gopath,
 		"log":            "/dev/null",
 		"git_user_name":  "ci-robot",
 		"git_user_email": "ci-robot@openshift.io",
-		"refs":           []interface{}{refs},
+		"refs":           refs,
 	}
 	optionsJSON, err := json.Marshal(optionsSpec)
 	if err != nil {
@@ -159,11 +167,11 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 				Strategy: buildapi.BuildStrategy{
 					Type: buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{
-						DockerfilePath: dockerfilePath,
-						From:           from,
-						ForcePull:      true,
-						NoCache:        true,
-						Env:            []coreapi.EnvVar{},
+						DockerfilePath:          dockerfilePath,
+						From:                    from,
+						ForcePull:               true,
+						NoCache:                 true,
+						Env:                     []coreapi.EnvVar{},
 						ImageOptimizationPolicy: &layer,
 					},
 				},


### PR DESCRIPTION
With the ability to compare ci-operator config we needed to implement a
structure that holds all ci-operator configs in memory. When inlining
ci-operator config to rehearsed jobs, we loaded from disk the config
file content to be inlined. This is no longer necessary, because we
already have that config in memory, so we can marshal it and inline the
result.

Because this works with marshaled ci-operator configs, I have bumped
the vendored  `ci-operator` in a separate commit, because marshaling
its types was improved recently in https://github.com/openshift/ci-operator/pull/277.

/cc @stevekuznetsov @droslean @bbguimaraes 