### PR TITLE
 rehearse: optimize git manipulation when loading configs

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -296,7 +296,9 @@ func getProwConfigs(candidatePath, baseSHA string) (*prowconfig.Config, *prowcon
 	return masterProwConfig, prowPRConfig, nil
 }
 
-func getTemplates(candidatePath string, baseSHA string) (map[string]*templateapi.Template, map[string]*templateapi.Template, error) {
+type CiTemplates map[string]*templateapi.Template
+
+func getTemplates(candidatePath string, baseSHA string) (CiTemplates, CiTemplates, error) {
 	templatesPath := filepath.Join(candidatePath, diffs.TemplatesPath)
 	currentSHA, err := getCurrentSHA(candidatePath)
 	if err != nil {

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -3,24 +3,16 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	prowconfig "k8s.io/test-infra/prow/config"
 	prowgithub "k8s.io/test-infra/prow/github"
 	pjdwapi "k8s.io/test-infra/prow/pod-utils/downwardapi"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	templateapi "github.com/openshift/api/template/v1"
-	templatescheme "github.com/openshift/client-go/template/clientset/versioned/scheme"
 
 	"github.com/openshift/ci-operator-prowgen/pkg/config"
 	"github.com/openshift/ci-operator-prowgen/pkg/diffs"
@@ -143,27 +135,44 @@ func main() {
 		}
 	}
 
-	prowConfig, prowPRConfig, err := getProwConfigs(o.releaseRepoPath, jobSpec.Refs.BaseSHA)
+	prConfig := config.GetAllConfigs(o.releaseRepoPath, logger)
+	masterConfig, err := config.GetAllConfigsFromSHA(o.releaseRepoPath, jobSpec.Refs.BaseSHA, logger)
 	if err != nil {
-		logger.WithError(err).Error("could not load prow configs")
+		logger.WithError(err).Error("could not load configuration from base revision of release repo")
 		gracefulExit(o.noFail, misconfigurationOutput)
 	}
 
-	ciopConfig, ciopPRConfig, err := getCiopConfigs(o.releaseRepoPath, jobSpec.Refs.BaseSHA)
-	if err != nil {
-		logger.WithError(err).Error("could not load ci-operator configs")
+	// We always need both Prow config versions, otherwise we cannot compare them
+	if masterConfig.Prow == nil || prConfig.Prow == nil {
+		logger.WithError(err).Error("could not load Prow configs from base or tested revision of release repo")
+		gracefulExit(o.noFail, misconfigurationOutput)
+	}
+	// We always need PR versions of templates and ciop config, otherwise we cannot provide them to rehearsed jobs
+	if prConfig.Templates == nil || prConfig.CiOperator == nil {
+		logger.WithError(err).Error("could not load template/ci-operator configs from tested revision of release repo")
 		gracefulExit(o.noFail, misconfigurationOutput)
 	}
 
-	pjclient, err := rehearse.NewProwJobClient(clusterConfig, prowConfig.ProwJobNamespace, o.dryRun)
+	// We can only detect changes if we managed to load both ci-operator config versions
+	if masterConfig.CiOperator != nil && prConfig.CiOperator != nil {
+		changedCiopConfigs := diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+		for name := range changedCiopConfigs {
+			logger.WithField("ciop-config", name).Info("Changed ci-operator config")
+		}
+	}
+
+	// We can only detect changes if we managed to load both CI template versions
+	if masterConfig.Templates != nil && prConfig.Templates != nil {
+		changedTemplates := diffs.GetChangedTemplates(masterConfig.Templates, prConfig.Templates, logger)
+		for name := range changedTemplates {
+			logger.WithField("template-name", name).Info("Changed template")
+		}
+	}
+
+	pjclient, err := rehearse.NewProwJobClient(clusterConfig, masterConfig.Prow.ProwJobNamespace, o.dryRun)
 	if err != nil {
 		logger.WithError(err).Error("could not create a ProwJob client")
 		gracefulExit(o.noFail, misconfigurationOutput)
-	}
-
-	changedCiopConfigs := diffs.GetChangedCiopConfigs(ciopConfig, ciopPRConfig, logger)
-	for name := range changedCiopConfigs {
-		logger.WithField("ciop-config", name).Info("Changed ci-operator config")
 	}
 
 	debugLogger := logrus.New()
@@ -179,8 +188,8 @@ func main() {
 	}
 	loggers := rehearse.Loggers{Job: logger, Debug: debugLogger.WithField(prowgithub.PrLogField, prNumber)}
 
-	changedPresubmits := diffs.GetChangedPresubmits(prowConfig, prowPRConfig, logger)
-	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPRConfig, prNumber, loggers, o.allowVolumes)
+	changedPresubmits := diffs.GetChangedPresubmits(masterConfig.Prow, prConfig.Prow, logger)
+	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, prConfig.CiOperator, prNumber, loggers, o.allowVolumes)
 	if len(rehearsals) == 0 {
 		logger.Info("no jobs to rehearse have been found")
 		os.Exit(0)
@@ -193,16 +202,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	masterTemplates, prTemplates, err := getTemplates(o.releaseRepoPath, jobSpec.Refs.BaseSHA)
-	if err != nil {
-		logger.WithError(err).Error("could not load templates")
-	}
-
-	changedTemplates := diffs.GetChangedTemplates(masterTemplates, prTemplates, logger)
-	for name := range changedTemplates {
-		logger.WithField("template-name", name).Info("Changed template")
-	}
-
 	executor := rehearse.NewExecutor(rehearsals, prNumber, o.releaseRepoPath, jobSpec.Refs, o.dryRun, loggers, pjclient)
 	success, err := executor.ExecuteJobs()
 	if err != nil {
@@ -213,149 +212,5 @@ func main() {
 		logger.Error("Some jobs failed their rehearsal runs")
 		gracefulExit(o.noFail, jobsFailureOutput)
 	}
-	logger.Info("All jobs were rehearsed successfuly")
-}
-
-func getCurrentSHA(repoPath string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = repoPath
-	sha, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("'%s' failed with error=%v", cmd.Args, err)
-	}
-
-	return strings.TrimSpace(string(sha)), nil
-}
-
-func gitCheckout(candidatePath, baseSHA string) error {
-	cmd := exec.Command("git", "checkout", baseSHA)
-	cmd.Dir = candidatePath
-	stdoutStderr, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("'%s' failed with out: %s and error %v", cmd.Args, stdoutStderr, err)
-	}
-	return nil
-}
-
-func getCiopConfigs(candidatePath, baseSHA string) (config.CompoundCiopConfig, config.CompoundCiopConfig, error) {
-	currentSHA, err := getCurrentSHA(candidatePath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get SHA of current HEAD: %v", err)
-	}
-
-	candidateConfigPath := filepath.Join(candidatePath, diffs.CiopConfigInRepoPath)
-
-	prCiopConfig, err := config.CompoundLoad(candidateConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load PR's ci-operator configs")
-	}
-
-	if err := gitCheckout(candidatePath, baseSHA); err != nil {
-		return nil, nil, fmt.Errorf("failed to checkout worktree: %v", err)
-	}
-
-	masterCiopConfig, err := config.CompoundLoad(candidateConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load base ci-operator configs")
-	}
-
-	if err := gitCheckout(candidatePath, currentSHA); err != nil {
-		return nil, nil, fmt.Errorf("failed to check out tested revision back: %v", err)
-	}
-
-	return masterCiopConfig, prCiopConfig, nil
-}
-
-func getProwConfigs(candidatePath, baseSHA string) (*prowconfig.Config, *prowconfig.Config, error) {
-	currentSHA, err := getCurrentSHA(candidatePath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get SHA of current HEAD: %v", err)
-	}
-
-	candidateConfigPath := filepath.Join(candidatePath, diffs.ConfigInRepoPath)
-	candidateJobConfigPath := filepath.Join(candidatePath, diffs.JobConfigInRepoPath)
-
-	prowPRConfig, err := prowconfig.Load(candidateConfigPath, candidateJobConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load PR's Prow config: %v", err)
-	}
-
-	if err := gitCheckout(candidatePath, baseSHA); err != nil {
-		return nil, nil, fmt.Errorf("could not checkout worktree: %v", err)
-	}
-
-	masterProwConfig, err := prowconfig.Load(candidateConfigPath, candidateJobConfigPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load master's Prow config: %v", err)
-	}
-
-	if err := gitCheckout(candidatePath, currentSHA); err != nil {
-		return nil, nil, fmt.Errorf("failed to check out tested revision back: %v", err)
-	}
-
-	return masterProwConfig, prowPRConfig, nil
-}
-
-type CiTemplates map[string]*templateapi.Template
-
-func getTemplates(candidatePath string, baseSHA string) (CiTemplates, CiTemplates, error) {
-	templatesPath := filepath.Join(candidatePath, diffs.TemplatesPath)
-	currentSHA, err := getCurrentSHA(candidatePath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get SHA of current HEAD: %v", err)
-	}
-
-	prTemplates, err := parseTemplates(templatesPath)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := gitCheckout(candidatePath, baseSHA); err != nil {
-		return nil, nil, fmt.Errorf("could not checkout worktree: %v", err)
-	}
-	masterTemplates, err := parseTemplates(templatesPath)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := gitCheckout(candidatePath, currentSHA); err != nil {
-		return nil, nil, fmt.Errorf("failed to check out tested revision back: %v", err)
-	}
-
-	return masterTemplates, prTemplates, nil
-}
-
-func parseTemplates(templatePath string) (map[string]*templateapi.Template, error) {
-	templates := make(map[string]*templateapi.Template)
-	err := filepath.Walk(templatePath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return fmt.Errorf("prevent panic by handling failure accessing a path %q: %v", path, err)
-		}
-
-		if isYAML(path, info) {
-			contents, err := ioutil.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("could not read file %s for template: %v", path, err)
-			}
-
-			if obj, _, err := templatescheme.Codecs.UniversalDeserializer().Decode(contents, nil, nil); err == nil {
-				if template, ok := obj.(*templateapi.Template); ok {
-					if len(template.Name) == 0 {
-						template.Name = filepath.Base(path)
-						template.Name = strings.TrimSuffix(template.Name, filepath.Ext(template.Name))
-					}
-					templates[template.Name] = template
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error walking the path %q: %v", templatePath, err)
-	}
-	return templates, nil
-}
-
-func isYAML(file string, info os.FileInfo) bool {
-	return !info.IsDir() && (filepath.Ext(file) == ".yaml" || filepath.Ext(file) == ".yml")
+	logger.Info("All jobs were rehearsed successfully")
 }

--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -128,11 +128,11 @@ func getExpectedProwJobs(t *testing.T) sets.String {
 }
 
 func getRehersalsHelper(logger *logrus.Entry, prNumber int) ([]*prowconfig.Presubmit, error) {
-	candidateConfigPath := filepath.Join(candidatePath, diffs.ConfigInRepoPath)
-	candidateJobConfigPath := filepath.Join(candidatePath, diffs.JobConfigInRepoPath)
-	candidateCiopConfigPath := filepath.Join(candidatePath, diffs.CiopConfigInRepoPath)
-	masterConfigPath := filepath.Join(masterPath, diffs.ConfigInRepoPath)
-	masterJobConfigPath := filepath.Join(masterPath, diffs.JobConfigInRepoPath)
+	candidateConfigPath := filepath.Join(candidatePath, config.ConfigInRepoPath)
+	candidateJobConfigPath := filepath.Join(candidatePath, config.JobConfigInRepoPath)
+	candidateCiopConfigPath := filepath.Join(candidatePath, config.CiopConfigInRepoPath)
+	masterConfigPath := filepath.Join(masterPath, config.ConfigInRepoPath)
+	masterJobConfigPath := filepath.Join(masterPath, config.JobConfigInRepoPath)
 
 	prowConfig, err := prowconfig.Load(masterConfigPath, masterJobConfigPath)
 	if err != nil {

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	prowconfig "k8s.io/test-infra/prow/config"
+)
+
+const (
+	// ConfigInRepoPath is the prow config path from release repo
+	ConfigInRepoPath = "cluster/ci/config/prow/config.yaml"
+	// JobConfigInRepoPath is the prowjobs path from release repo
+	JobConfigInRepoPath = "ci-operator/jobs"
+	// CiopConfigInRepoPath is the ci-operator config path from release repo
+	CiopConfigInRepoPath = "ci-operator/config"
+	// TemplatesPath is the path of the templates from release repo
+	TemplatesPath = "ci-operator/templates"
+)
+
+// ReleaseRepoConfig contains all configuration present in release repo (usually openshift/release)
+type ReleaseRepoConfig struct {
+	Prow       *prowconfig.Config
+	CiOperator CompoundCiopConfig
+	Templates  CiTemplates
+}
+
+func getCurrentSHA(repoPath string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = repoPath
+	sha, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("'%s' failed with error=%v", cmd.Args, err)
+	}
+
+	return strings.TrimSpace(string(sha)), nil
+}
+
+func gitCheckout(candidatePath, baseSHA string) error {
+	cmd := exec.Command("git", "checkout", baseSHA)
+	cmd.Dir = candidatePath
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("'%s' failed with out: %s and error %v", cmd.Args, stdoutStderr, err)
+	}
+	return nil
+}
+
+// GetAllConfigs loads all configuration from the working copy of the release repo (usually openshift/release).
+// When an error occurs during some config loading, the error is not propagated, but the returned struct field will
+// have a nil value in the appropriate field. The error is only logged.
+func GetAllConfigs(releaseRepoPath string, logger *logrus.Entry) *ReleaseRepoConfig {
+	config := &ReleaseRepoConfig{}
+	var err error
+
+	templatePath := filepath.Join(releaseRepoPath, TemplatesPath)
+	config.Templates, err = getTemplates(templatePath)
+	if err != nil {
+		logger.WithError(err).Warn("failed to load templates from release repo")
+	}
+
+	ciopConfigPath := filepath.Join(releaseRepoPath, CiopConfigInRepoPath)
+	config.CiOperator, err = CompoundLoad(ciopConfigPath)
+	if err != nil {
+		logger.WithError(err).Warn("failed to load ci-operator configuration from release repo")
+	}
+
+	prowConfigPath := filepath.Join(releaseRepoPath, ConfigInRepoPath)
+	prowJobConfigPath := filepath.Join(releaseRepoPath, JobConfigInRepoPath)
+	config.Prow, err = prowconfig.Load(prowConfigPath, prowJobConfigPath)
+	if err != nil {
+		logger.WithError(err).Warn("failed to load Prow configuration from release repo")
+	}
+
+	return config
+}
+
+// GetAllConfigsFromSHA loads all configuration from given SHA revision of the release repo (usually openshift/release).
+// This method checks out the given revision before the configuration is loaded, and then checks out back the saved
+// revision that was checked out in the working copy when this method was called. Errors occurred during these git
+// manipulations are propagated in the error return value. Errors occurred during the actual config loading are not
+// propagated, but the returned struct field will have a nil value in the appropriate field. The error is only logged.
+func GetAllConfigsFromSHA(releaseRepoPath, sha string, logger *logrus.Entry) (*ReleaseRepoConfig, error) {
+	currentSHA, err := getCurrentSHA(releaseRepoPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SHA of current HEAD: %v", err)
+	}
+
+	if err := gitCheckout(releaseRepoPath, sha); err != nil {
+		return nil, fmt.Errorf("could not checkout worktree: %v", err)
+	}
+
+	config := GetAllConfigs(releaseRepoPath, logger)
+
+	if err := gitCheckout(releaseRepoPath, currentSHA); err != nil {
+		return config, fmt.Errorf("failed to check out tested revision back: %v", err)
+	}
+
+	return config, nil
+}

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	templateapi "github.com/openshift/api/template/v1"
+	templatescheme "github.com/openshift/client-go/template/clientset/versioned/scheme"
+)
+
+type CiTemplates map[string]*templateapi.Template
+
+func getTemplates(templatePath string) (CiTemplates, error) {
+	templates := make(map[string]*templateapi.Template)
+	err := filepath.Walk(templatePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("prevent panic by handling failure accessing a path %q: %v", path, err)
+		}
+
+		if isYAML(path, info) {
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("could not read file %s for template: %v", path, err)
+			}
+
+			if obj, _, err := templatescheme.Codecs.UniversalDeserializer().Decode(contents, nil, nil); err == nil {
+				if template, ok := obj.(*templateapi.Template); ok {
+					if len(template.Name) == 0 {
+						template.Name = filepath.Base(path)
+						template.Name = strings.TrimSuffix(template.Name, filepath.Ext(template.Name))
+					}
+					templates[template.Name] = template
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error walking the path %q: %v", templatePath, err)
+	}
+	return templates, nil
+}
+
+func isYAML(file string, info os.FileInfo) bool {
+	return !info.IsDir() && (filepath.Ext(file) == ".yaml" || filepath.Ext(file) == ".yml")
+}

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -18,15 +18,6 @@ import (
 )
 
 const (
-	// ConfigInRepoPath is the prow config path from release repo
-	ConfigInRepoPath = "cluster/ci/config/prow/config.yaml"
-	// JobConfigInRepoPath is the prowjobs path from release repo
-	JobConfigInRepoPath = "ci-operator/jobs"
-	// TemplatesPath is the path of the templates from release repo
-	TemplatesPath = "ci-operator/templates"
-	// CiopConfigInRepoPath is the ci-operator config path from release repo
-	CiopConfigInRepoPath = "ci-operator/config"
-
 	logRepo       = "repo"
 	logJobName    = "job-name"
 	logDiffs      = "diffs"


### PR DESCRIPTION
Previously we loaded all three CI config fragments (Prow config,
ci-operator config, templates) separately. Because we need to load the
configs from two different revisions of the release repo, all three
loading methods handled the "check out master revision, load config,
check out tested revision" procedure themselves, which resulted in the
whole operation being performed three times unnecessarily. This was
optimized so that we separate loading of all config from the git
operation.

A little tricky area is the error handling and propagation. The errors
occurred during config loading itself are not propagated via error values
but by the appropriate field of the config having a nil value. This is
because we need granular information about which configs loaded
correctly and which not, so the tool can decide a right course of
action. The decisions are as follows:

- Exit when any Prow config version loading failed, because we need to
  compare both versions to compute which jobs should be rehearsed.
- Exit when PR version of templates or ci-operator config loading
  failed, because we need these versions to provide them to rehearsed
  jobs.
- Do not compare templates when master version of templates fails to
  load.
- Do not compare ci-operator config when master version of these configs
  fails to load.