### PR TITLE
pj-rehearse - Add configMaps logic on changed templates

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -100,6 +100,15 @@ func gracefulExit(suppressFailures bool, message string) {
 	os.Exit(1)
 }
 
+func gracefulExitWithConfigMapCleanup(suppressFailures bool, message string, cmManager *config.TemplateCMManager) {
+	if cmManager != nil {
+		if err := cmManager.CleanupCMTemplates(); err != nil {
+			fmt.Fprintln(os.Stderr, "Failed to cleanup temporary configmaps")
+		}
+	}
+	gracefulExit(suppressFailures, message)
+}
+
 func main() {
 	o := gatherOptions()
 	err := validateOptions(o)
@@ -191,13 +200,13 @@ func main() {
 	cmManager := config.NewTemplateCMManager(cmClient, prNumber, logger, changedTemplates)
 	if err := cmManager.CreateCMTemplates(); err != nil {
 		logger.WithError(err).Error("couldn't create template configMap")
-		gracefulExit(o.noFail, "")
+		gracefulExitWithConfigMapCleanup(o.noFail, "", cmManager)
 	}
 
 	pjclient, err := rehearse.NewProwJobClient(clusterConfig, namespace, o.dryRun)
 	if err != nil {
 		logger.WithError(err).Error("could not create a ProwJob client")
-		gracefulExit(o.noFail, misconfigurationOutput)
+		gracefulExitWithConfigMapCleanup(o.noFail, misconfigurationOutput, cmManager)
 	}
 
 	debugLogger := logrus.New()
@@ -208,7 +217,7 @@ func main() {
 			debugLogger.Out = f
 		} else {
 			logger.WithError(err).Error("could not open debug log file")
-			gracefulExit(o.noFail, "")
+			gracefulExitWithConfigMapCleanup(o.noFail, "", cmManager)
 		}
 	}
 	loggers := rehearse.Loggers{Job: logger, Debug: debugLogger.WithField(prowgithub.PrLogField, prNumber)}
@@ -219,25 +228,29 @@ func main() {
 	rehearsals := rehearse.ConfigureRehearsalJobs(toRehearse, prConfig.CiOperator, prNumber, loggers, o.allowVolumes, changedTemplates)
 	if len(rehearsals) == 0 {
 		logger.Info("no jobs to rehearse have been found")
-		gracefulExit(true, "")
+		gracefulExitWithConfigMapCleanup(true, "", cmManager)
 	} else if len(rehearsals) > o.rehearsalLimit {
 		jobCountFields := logrus.Fields{
 			"rehearsal-threshold": o.rehearsalLimit,
 			"rehearsal-jobs":      len(rehearsals),
 		}
 		logger.WithFields(jobCountFields).Info("Would rehearse too many jobs, will not proceed")
-		gracefulExit(true, "")
+		gracefulExitWithConfigMapCleanup(true, "", cmManager)
 	}
 
 	executor := rehearse.NewExecutor(rehearsals, prNumber, o.releaseRepoPath, jobSpec.Refs, o.dryRun, loggers, pjclient)
 	success, err := executor.ExecuteJobs()
 	if err != nil {
 		logger.WithError(err).Error("Failed to rehearse jobs")
-		gracefulExit(o.noFail, rehearseFailureOutput)
+		gracefulExitWithConfigMapCleanup(o.noFail, rehearseFailureOutput, cmManager)
 	}
 	if !success {
 		logger.Error("Some jobs failed their rehearsal runs")
-		gracefulExit(o.noFail, jobsFailureOutput)
+		gracefulExitWithConfigMapCleanup(o.noFail, jobsFailureOutput, cmManager)
 	}
 	logger.Info("All jobs were rehearsed successfully")
+
+	if err := cmManager.CleanupCMTemplates(); err != nil {
+		logger.WithError(err).Error("Failed to cleanup temporary configmaps")
+	}
 }

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -168,9 +168,10 @@ func main() {
 		changedCiopConfigs = diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
 	}
 
+	var changedTemplates config.CiTemplates
 	// We can only detect changes if we managed to load both CI template versions
 	if masterConfig.Templates != nil && prConfig.Templates != nil {
-		changedTemplates := diffs.GetChangedTemplates(masterConfig.Templates, prConfig.Templates, logger)
+		changedTemplates = diffs.GetChangedTemplates(masterConfig.Templates, prConfig.Templates, logger)
 		for name := range changedTemplates {
 			logger.WithField("template-name", name).Info("Changed template")
 		}
@@ -202,7 +203,7 @@ func main() {
 	toRehearse := diffs.GetChangedPresubmits(masterConfig.Prow, prConfig.Prow, logger)
 	toRehearse.AddAll(diffs.GetPresubmitsForCiopConfigs(prConfig.Prow, changedCiopConfigs, logger))
 
-	rehearsals := rehearse.ConfigureRehearsalJobs(toRehearse, prConfig.CiOperator, prNumber, loggers, o.allowVolumes)
+	rehearsals := rehearse.ConfigureRehearsalJobs(toRehearse, prConfig.CiOperator, prNumber, loggers, o.allowVolumes, changedTemplates)
 	if len(rehearsals) == 0 {
 		logger.Info("no jobs to rehearse have been found")
 		os.Exit(0)

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -168,7 +168,7 @@ func main() {
 		changedCiopConfigs = diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
 	}
 
-	var changedTemplates config.CiTemplates
+	changedTemplates := make(config.CiTemplates)
 	// We can only detect changes if we managed to load both CI template versions
 	if masterConfig.Templates != nil && prConfig.Templates != nil {
 		changedTemplates = diffs.GetChangedTemplates(masterConfig.Templates, prConfig.Templates, logger)

--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -162,7 +162,7 @@ func getRehersalsHelper(logger *logrus.Entry, prNumber int) ([]*prowconfig.Presu
 	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger))
 
 	var cmClient coreclientset.ConfigMapInterface
-	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, cmClient, nil, true)
+	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, cmClient, nil)
 
 	return rehearsals, nil
 }

--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 
-	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	clienttesting "k8s.io/client-go/testing"
 
 	"k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -161,8 +160,7 @@ func getRehersalsHelper(logger *logrus.Entry, prNumber int) ([]*prowconfig.Presu
 	changedCiopConfigs := diffs.GetChangedCiopConfigs(ciopMasterConfig, ciopPrConfig, logger)
 	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger))
 
-	var cmClient coreclientset.ConfigMapInterface
-	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, cmClient, nil)
+	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, nil)
 
 	return rehearsals, nil
 }

--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 
+	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	clienttesting "k8s.io/client-go/testing"
 
 	"k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -160,6 +161,8 @@ func getRehersalsHelper(logger *logrus.Entry, prNumber int) ([]*prowconfig.Presu
 	changedCiopConfigs := diffs.GetChangedCiopConfigs(ciopMasterConfig, ciopPrConfig, logger)
 	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger))
 
-	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false)
+	var cmClient coreclientset.ConfigMapInterface
+	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, cmClient, nil, true)
+
 	return rehearsals, nil
 }

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1,17 +1,38 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	templateapi "github.com/openshift/api/template/v1"
 	templatescheme "github.com/openshift/client-go/template/clientset/versioned/scheme"
+
+	"k8s.io/api/core/v1"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
+// CiTemplates is a map of all the changed templates
 type CiTemplates map[string]*templateapi.Template
+
+const (
+	createByRehearse  = "created-by-pj-rehearse"
+	rehearseLabelPull = "ci.openshift.org/rehearse-pull"
+)
 
 func getTemplates(templatePath string) (CiTemplates, error) {
 	templates := make(map[string]*templateapi.Template)
@@ -46,4 +67,78 @@ func getTemplates(templatePath string) (CiTemplates, error) {
 
 func isYAML(file string, info os.FileInfo) bool {
 	return !info.IsDir() && (filepath.Ext(file) == ".yaml" || filepath.Ext(file) == ".yml")
+}
+
+// TemplateCMManager holds the details needed for the configmap controller
+type TemplateCMManager struct {
+	cmclient  corev1.ConfigMapInterface
+	prNumber  int
+	logger    *logrus.Entry
+	templates CiTemplates
+}
+
+// NewTemplateCMManager creates a new TemplateCMManager
+func NewTemplateCMManager(cmclient corev1.ConfigMapInterface, prNumber int, logger *logrus.Entry, templates CiTemplates) *TemplateCMManager {
+	return &TemplateCMManager{
+		cmclient:  cmclient,
+		prNumber:  prNumber,
+		logger:    logger,
+		templates: templates,
+	}
+}
+
+// CreateCMTemplates creates configMaps for all the changed templates.
+func (c *TemplateCMManager) CreateCMTemplates() error {
+	var errors []error
+	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+
+	for filename, template := range c.templates {
+		buf := new(bytes.Buffer)
+
+		err := s.Encode(template, buf)
+		if err != nil {
+			errors = append(errors, err)
+		}
+
+		cmName := getTempCMName(c.prNumber, template.Name)
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cmName,
+				Labels: map[string]string{
+					createByRehearse:  "true",
+					rehearseLabelPull: strconv.Itoa(c.prNumber),
+				},
+			},
+			Data: map[string]string{filename: buf.String()},
+		}
+
+		c.logger.WithFields(logrus.Fields{"template-name": template.Name, "cm-name": cmName}).Info("creating rehearsal configMap for template")
+		if _, err := c.cmclient.Create(cm); err != nil {
+			if kerrors.IsAlreadyExists(err) {
+				if _, err := c.cmclient.Update(cm); err != nil {
+					errors = append(errors, fmt.Errorf("could not update existing configmap: %v", err))
+				}
+			} else {
+				errors = append(errors, err)
+			}
+		}
+	}
+	return kutilerrors.NewAggregate(errors)
+}
+
+// CleanupCMTemplates deletes all the configMaps that have been created for the changed templates.
+func (c *TemplateCMManager) CleanupCMTemplates() error {
+	c.logger.Info("deleting temporary template configMaps")
+	if err := c.cmclient.DeleteCollection(&metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: fields.Set{
+			createByRehearse:  "true",
+			rehearseLabelPull: strconv.Itoa(c.prNumber),
+		}.AsSelector().String()}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getTempCMName(prNumber int, templateName string) string {
+	return fmt.Sprintf("rehearse-%d-%s", prNumber, templateName)
 }

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -139,6 +139,7 @@ func (c *TemplateCMManager) CleanupCMTemplates() error {
 	return nil
 }
 
+// GetTempCMName converts a template name to a temporary name including the pr number.
 func GetTempCMName(prNumber int, templateName string) string {
 	return fmt.Sprintf("rehearse-%d-%s", prNumber, templateName)
 }

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -100,7 +100,7 @@ func (c *TemplateCMManager) CreateCMTemplates() error {
 			errors = append(errors, err)
 		}
 
-		cmName := getTempCMName(c.prNumber, template.Name)
+		cmName := GetTempCMName(c.prNumber, template.Name)
 		cm := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cmName,
@@ -139,6 +139,6 @@ func (c *TemplateCMManager) CleanupCMTemplates() error {
 	return nil
 }
 
-func getTempCMName(prNumber int, templateName string) string {
+func GetTempCMName(prNumber int, templateName string) string {
 	return fmt.Sprintf("rehearse-%d-%s", prNumber, templateName)
 }

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -32,7 +32,7 @@ func getTemplates(templatePath string) (CiTemplates, error) {
 						template.Name = filepath.Base(path)
 						template.Name = strings.TrimSuffix(template.Name, filepath.Ext(template.Name))
 					}
-					templates[template.Name] = template
+					templates[filepath.Base(path)] = template
 				}
 			}
 		}

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	templateapi "github.com/openshift/api/template/v1"
+	templatescheme "github.com/openshift/client-go/template/clientset/versioned/scheme"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/fake"
+	coretesting "k8s.io/client-go/testing"
+)
+
+const templatesPath = "../../test/pj-rehearse-integration/master/ci-operator/templates"
+
+func TestGetTemplates(t *testing.T) {
+	expectCiTemplates := getBaseCiTemplates(t)
+	if templates, err := getTemplates(templatesPath); err != nil {
+		t.Fatalf("getTemplates() returned error: %v", err)
+	} else if !equality.Semantic.DeepEqual(templates, expectCiTemplates) {
+		t.Fatalf("Diff found %s", diff.ObjectReflectDiff(expectCiTemplates, templates))
+	}
+}
+
+func TestCreateCleanupCMTemplates(t *testing.T) {
+	expectedCmName := "rehearse-1234-test-template"
+	expectedCmLabels := map[string]string{
+		createByRehearse:  "true",
+		rehearseLabelPull: "1234",
+	}
+
+	createByRehearseReq, err := labels.NewRequirement(createByRehearse, selection.Equals, []string{"true"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rehearseLabelPullReq, err := labels.NewRequirement(rehearseLabelPull, selection.Equals, []string{"1234"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	selector := labels.NewSelector().Add(*createByRehearseReq).Add(*rehearseLabelPullReq)
+
+	expectedListRestricitons := coretesting.ListRestrictions{
+		Labels: selector,
+	}
+
+	cs := fake.NewSimpleClientset()
+	cs.Fake.AddReactor("create", "configmaps", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(coretesting.CreateAction)
+		cm := createAction.GetObject().(*v1.ConfigMap)
+
+		if cm.ObjectMeta.Name != expectedCmName {
+			t.Fatalf("Configmap name:\nExpected: %s\nFound: %s", expectedCmName, cm.ObjectMeta.Name)
+		}
+
+		if !reflect.DeepEqual(cm.ObjectMeta.Labels, expectedCmLabels) {
+			t.Fatalf("Configmap labels\nExpected: %#v\nFound: %#v", expectedCmLabels, cm.ObjectMeta.Labels)
+		}
+
+		return true, nil, nil
+	})
+	cs.Fake.AddReactor("delete-collection", "configmaps", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+		deleteAction := action.(coretesting.DeleteCollectionAction)
+		listRestricitons := deleteAction.GetListRestrictions()
+
+		if !reflect.DeepEqual(listRestricitons.Labels, expectedListRestricitons.Labels) {
+			t.Fatalf("Labels:\nExpected:%#v\nFound: %#v", expectedListRestricitons.Labels, listRestricitons.Labels)
+		}
+
+		return true, nil, nil
+	})
+
+	ciTemplates := getBaseCiTemplates(t)
+	cmManager := NewTemplateCMManager(cs.CoreV1().ConfigMaps("test-namespace"), 1234, logrus.NewEntry(logrus.New()), ciTemplates)
+
+	if err := cmManager.CreateCMTemplates(); err != nil {
+		t.Fatalf("CreateCMTemplates() returned error: %v", err)
+	}
+
+	if err := cmManager.CleanupCMTemplates(); err != nil {
+		t.Fatalf("CleanupCMTemplates() returned error: %v", err)
+	}
+
+}
+
+func getBaseCiTemplates(t *testing.T) CiTemplates {
+	testTemplatePath := filepath.Join(templatesPath, "test-template.yaml")
+	contents, err := ioutil.ReadFile(testTemplatePath)
+	if err != nil {
+		t.Fatalf("could not read file %s for template: %v", testTemplatePath, err)
+	}
+
+	var expectedTemplate *templateapi.Template
+	if obj, _, err := templatescheme.Codecs.UniversalDeserializer().Decode(contents, nil, nil); err == nil {
+		if template, ok := obj.(*templateapi.Template); ok {
+			if len(template.Name) == 0 {
+				template.Name = filepath.Base(testTemplatePath)
+				template.Name = strings.TrimSuffix(template.Name, filepath.Ext(template.Name))
+			}
+			expectedTemplate = template
+		}
+	}
+
+	return CiTemplates{
+		"test-template.yaml": expectedTemplate,
+	}
+}

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -12,8 +12,6 @@ import (
 	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 
-	templateapi "github.com/openshift/api/template/v1"
-
 	"github.com/openshift/ci-operator-prowgen/pkg/config"
 )
 
@@ -130,8 +128,8 @@ func convertToReadableDiff(a, b interface{}, objName string) string {
 }
 
 // GetChangedTemplates returns a mapping of the changed templates to be rehearsed.
-func GetChangedTemplates(masterTemplates, prTemplates map[string]*templateapi.Template, logger *logrus.Entry) map[string]*templateapi.Template {
-	changedTemplates := make(map[string]*templateapi.Template)
+func GetChangedTemplates(masterTemplates, prTemplates config.CiTemplates, logger *logrus.Entry) config.CiTemplates {
+	changedTemplates := make(config.CiTemplates)
 
 	for name, template := range prTemplates {
 		logFields := logrus.Fields{"template-name": name}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -292,7 +292,7 @@ func TestGetChangedTemplates(t *testing.T) {
 	testCases := []struct {
 		name         string
 		getTemplates func() (map[string]*templateapi.Template, map[string]*templateapi.Template)
-		expected     map[string]*templateapi.Template
+		expected     config.CiTemplates
 	}{
 		{
 			name: "no changes",
@@ -300,7 +300,7 @@ func TestGetChangedTemplates(t *testing.T) {
 				templates := makeBaseTemplates(baseParameters, baseObjects)
 				return templates, templates
 			},
-			expected: map[string]*templateapi.Template{},
+			expected: config.CiTemplates{},
 		},
 		{
 			name: "add new template",
@@ -344,7 +344,7 @@ func TestGetChangedTemplates(t *testing.T) {
 					})
 				return makeBaseTemplates(baseParameters, baseObjects), prTemplates
 			},
-			expected: map[string]*templateapi.Template{
+			expected: config.CiTemplates{
 				"template1": {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "template1",

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -67,7 +67,7 @@ func NewCMClient(clusterConfig *rest.Config, namespace string, dry bool) (corecl
 
 	cmClient, err := coreclientset.NewForConfig(clusterConfig)
 	if err != nil {
-		fmt.Errorf("could not get core client for cluster config: %v", err)
+		return nil, fmt.Errorf("could not get core client for cluster config: %v", err)
 	}
 
 	return cmClient.ConfigMaps(namespace), nil

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
-	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientgo_testing "k8s.io/client-go/testing"
 
 	"github.com/openshift/ci-operator/pkg/api"
@@ -304,8 +303,7 @@ func TestExecuteJobsErrors(t *testing.T) {
 				return false, nil, nil
 			})
 
-			var cmClient coreclientset.ConfigMapInterface
-			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, cmClient, nil, true)
+			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, nil)
 			executor := NewExecutor(rehearsals, testPrNumber, testRepoPath, testRefs, true, testLoggers, fakeclient)
 			_, err = executor.ExecuteJobs()
 
@@ -374,8 +372,7 @@ func TestExecuteJobsUnsuccessful(t *testing.T) {
 				return true, ret, nil
 			})
 
-			var cmClient coreclientset.ConfigMapInterface
-			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, cmClient, nil, true)
+			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, nil)
 			executor := NewExecutor(rehearsals, testPrNumber, testRepoPath, testRefs, false, testLoggers, fakeclient)
 			success, _ := executor.ExecuteJobs()
 
@@ -480,8 +477,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 			}
 			fakecs.Fake.PrependWatchReactor("prowjobs", makeSuccessfulFinishReactor(watcher, tc.jobs))
 
-			var cmClient coreclientset.ConfigMapInterface
-			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, cmClient, nil, true)
+			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, nil)
 			executor := NewExecutor(rehearsals, testPrNumber, testRepoPath, testRefs, true, testLoggers, fakeclient)
 			success, err := executor.ExecuteJobs()
 

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -777,9 +777,9 @@ func TestHasChangedTemplateVolume(t *testing.T) {
 	}
 
 	type expectedToFind struct {
-		exists       bool
-		index        int
-		templateName string
+		exists      bool
+		index       int
+		templateKey string
 	}
 
 	testCases := []struct {
@@ -809,9 +809,9 @@ func TestHasChangedTemplateVolume(t *testing.T) {
 			},
 			jobVolumes: createVolumesHelper("job-definition", "test-template.yaml"),
 			expectedToFind: expectedToFind{
-				exists:       true,
-				index:        2,
-				templateName: "test-template",
+				exists:      true,
+				index:       2,
+				templateKey: "test-template.yaml",
 			},
 		},
 		{
@@ -829,9 +829,9 @@ func TestHasChangedTemplateVolume(t *testing.T) {
 			},
 			jobVolumes: append(createVolumesHelper("job-definition", "test-template.yaml"), createVolumesHelper("job-definition2", "test-template2.yaml")...),
 			expectedToFind: expectedToFind{
-				exists:       true,
-				index:        2,
-				templateName: "test-template",
+				exists:      true,
+				index:       2,
+				templateKey: "test-template.yaml",
 			},
 		},
 		{
@@ -854,11 +854,11 @@ func TestHasChangedTemplateVolume(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			exists, index, templateName := hasChangedTemplateVolume(testCase.jobVolumeMounts, testCase.jobVolumes, templates)
+			exists, index, templateKey := hasChangedTemplateVolume(testCase.jobVolumeMounts, testCase.jobVolumes, templates)
 			found := expectedToFind{
-				exists:       exists,
-				index:        index,
-				templateName: templateName,
+				exists:      exists,
+				index:       index,
+				templateKey: templateKey,
 			}
 			if !reflect.DeepEqual(testCase.expectedToFind, found) {
 				t.Fatalf("Expected:%v\nFound:%v", testCase.expectedToFind, found)

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
+	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientgo_testing "k8s.io/client-go/testing"
 
 	"github.com/openshift/ci-operator/pkg/api"
@@ -303,7 +304,8 @@ func TestExecuteJobsErrors(t *testing.T) {
 				return false, nil, nil
 			})
 
-			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true)
+			var cmClient coreclientset.ConfigMapInterface
+			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, cmClient, nil, true)
 			executor := NewExecutor(rehearsals, testPrNumber, testRepoPath, testRefs, true, testLoggers, fakeclient)
 			_, err = executor.ExecuteJobs()
 
@@ -372,7 +374,8 @@ func TestExecuteJobsUnsuccessful(t *testing.T) {
 				return true, ret, nil
 			})
 
-			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true)
+			var cmClient coreclientset.ConfigMapInterface
+			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, cmClient, nil, true)
 			executor := NewExecutor(rehearsals, testPrNumber, testRepoPath, testRefs, false, testLoggers, fakeclient)
 			success, _ := executor.ExecuteJobs()
 
@@ -477,7 +480,8 @@ func TestExecuteJobsPositive(t *testing.T) {
 			}
 			fakecs.Fake.PrependWatchReactor("prowjobs", makeSuccessfulFinishReactor(watcher, tc.jobs))
 
-			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true)
+			var cmClient coreclientset.ConfigMapInterface
+			rehearsals := ConfigureRehearsalJobs(tc.jobs, testCiopConfigs, testPrNumber, testLoggers, true, cmClient, nil, true)
 			executor := NewExecutor(rehearsals, testPrNumber, testRepoPath, testRefs, true, testLoggers, fakeclient)
 			success, err := executor.ExecuteJobs()
 

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -2,6 +2,7 @@ package rehearse
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strconv"
 	"testing"
@@ -23,11 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
+
 	clientgo_testing "k8s.io/client-go/testing"
 
-	"github.com/openshift/ci-operator/pkg/api"
-
+	templateapi "github.com/openshift/api/template/v1"
 	"github.com/openshift/ci-operator-prowgen/pkg/config"
+	"github.com/openshift/ci-operator/pkg/api"
 )
 
 func makeTestingPresubmitForEnv(env []v1.EnvVar) *prowconfig.Presubmit {
@@ -753,4 +755,153 @@ func makeBasePresubmit() *prowconfig.Presubmit {
 		Context:      "ci/prow/test",
 		Brancher:     prowconfig.Brancher{Branches: []string{"^master$"}},
 	}
+}
+
+func TestHasChangedTemplateVolume(t *testing.T) {
+	templates := config.CiTemplates{
+		"test-template.yaml": &templateapi.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-template",
+			},
+		},
+		"test-template2.yaml": &templateapi.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-template2",
+			},
+		},
+		"test-template3.yaml": &templateapi.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-template3",
+			},
+		},
+	}
+
+	type expectedToFind struct {
+		exists       bool
+		index        int
+		templateName string
+	}
+
+	testCases := []struct {
+		description     string
+		jobVolumeMounts []v1.VolumeMount
+		jobVolumes      []v1.Volume
+		expectedToFind  expectedToFind
+	}{
+		{
+			description:     "no volumes",
+			jobVolumeMounts: []v1.VolumeMount{},
+			jobVolumes:      []v1.Volume{},
+			expectedToFind:  expectedToFind{},
+		},
+		{
+			description: "find one in multiple volumes",
+			jobVolumeMounts: []v1.VolumeMount{
+				{
+					Name:      "non-template",
+					MountPath: "/tmp/test",
+				},
+				{
+					Name:      "job-definition",
+					MountPath: "/tmp/test",
+					SubPath:   "test-template.yaml",
+				},
+			},
+			jobVolumes: createVolumesHelper("job-definition", "test-template.yaml"),
+			expectedToFind: expectedToFind{
+				exists:       true,
+				index:        2,
+				templateName: "test-template",
+			},
+		},
+		{
+			description: "find one in multiple volumes that for some reason use two templates",
+			jobVolumeMounts: []v1.VolumeMount{
+				{
+					Name:      "non-template",
+					MountPath: "/tmp/test",
+				},
+				{
+					Name:      "job-definition",
+					MountPath: "/tmp/test",
+					SubPath:   "test-template.yaml",
+				},
+			},
+			jobVolumes: append(createVolumesHelper("job-definition", "test-template.yaml"), createVolumesHelper("job-definition2", "test-template2.yaml")...),
+			expectedToFind: expectedToFind{
+				exists:       true,
+				index:        2,
+				templateName: "test-template",
+			},
+		},
+		{
+			description: "find nothing in multiple volumes that use a template that is not changed",
+			jobVolumeMounts: []v1.VolumeMount{
+				{
+					Name:      "non-template",
+					MountPath: "/tmp/test",
+				},
+				{
+					Name:      "job-definition",
+					MountPath: "/tmp/test",
+					SubPath:   "test-template5.yaml",
+				},
+			},
+			jobVolumes:     createVolumesHelper("job-definition", "test-template5.yaml"),
+			expectedToFind: expectedToFind{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			exists, index, templateName := hasChangedTemplateVolume(testCase.jobVolumeMounts, testCase.jobVolumes, templates)
+			found := expectedToFind{
+				exists:       exists,
+				index:        index,
+				templateName: templateName,
+			}
+			if !reflect.DeepEqual(testCase.expectedToFind, found) {
+				t.Fatalf("Expected:%v\nFound:%v", testCase.expectedToFind, found)
+			}
+		})
+	}
+}
+
+func createVolumesHelper(name, key string) []v1.Volume {
+	volumes := []v1.Volume{
+		{
+			Name: "test-volume",
+			VolumeSource: v1.VolumeSource{
+				Projected: &v1.ProjectedVolumeSource{
+					Sources: []v1.VolumeProjection{
+						{
+							Secret: &v1.SecretProjection{
+								LocalObjectReference: v1.LocalObjectReference{Name: "test-secret"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "test-volume2",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+
+	volumes = append(volumes, v1.Volume{
+		Name: name,
+		VolumeSource: v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: "cluster-e2e-test-template"},
+				Items: []v1.KeyToPath{
+					{Key: key},
+				},
+			},
+		},
+	})
+
+	return volumes
 }


### PR DESCRIPTION
This PR adds the logic of the creation of temporary configMaps for the changed templates.

- [X] Create configMaps for all the changed templates
- [X] Cleanup all the temporary configMaps after the finish.
- [X] Detect if the jobs are using the changed template and use the temporary configMap instead.
- [X] Support this procedure only in dry-run false.
- [X] Add tests