### PR TITLE
Rehearse jobs that use changed ci-operator configs

### DIFF
--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	prowconfig "k8s.io/test-infra/prow/config"
+)
+
+type Presubmits map[string][]prowconfig.Presubmit
+
+// AddAll adds all jobs from a different instance.
+// The method assumes two jobs with a matching name for the same repository
+// are identical, so so if a presubmit with a given name already exists, it
+// is kept as is.
+func (p Presubmits) AddAll(jobs Presubmits) {
+	for repo := range jobs {
+		if _, ok := p[repo]; !ok {
+			p[repo] = []prowconfig.Presubmit{}
+		}
+
+		for _, sourceJob := range jobs[repo] {
+			p.Add(repo, sourceJob)
+		}
+	}
+}
+
+// Add a presubmit for a given repo.
+// The method assumes two jobs with a matching name are identical, so if
+// a presubmit with a given name already exists, it is kept as is.
+func (p Presubmits) Add(repo string, job prowconfig.Presubmit) {
+	for _, destJob := range p[repo] {
+		if destJob.Name == job.Name {
+			return
+		}
+	}
+
+	p[repo] = append(p[repo], job)
+}

--- a/pkg/config/jobs_test.go
+++ b/pkg/config/jobs_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"k8s.io/apimachinery/pkg/util/diff"
+	"reflect"
+	"testing"
+
+	prowconfig "k8s.io/test-infra/prow/config"
+)
+
+func TestPresubmitsAddAll(t *testing.T) {
+	testCases := []struct {
+		description string
+		source      Presubmits
+		destination Presubmits
+		expected    Presubmits
+	}{{
+		description: "merge empty structure into empty structure",
+	}, {
+		description: "merge empty structure into non-empty structure",
+		source:      Presubmits{},
+		destination: Presubmits{"org/repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-repo"}},
+		}},
+		expected: Presubmits{"org/repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-repo"}},
+		}},
+	}, {
+		description: "merge non-empty structure into empty structure",
+		source: Presubmits{"org/repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo"}},
+		}},
+		destination: Presubmits{},
+		expected: Presubmits{"org/repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo"}},
+		}},
+	}, {
+		description: "merge different jobs for a single repo, result should have both",
+		source: Presubmits{"org/repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo"}},
+		}},
+		destination: Presubmits{"org/repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-repo"}}}},
+		expected: Presubmits{"org/repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-repo"}},
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo"}},
+		}},
+	}, {
+		description: "merge jobs for different repos, result should have both",
+		source: Presubmits{"org/source-repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-source-repo"}},
+		}},
+		destination: Presubmits{"org/destination-repo": {
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-destination-repo"}}}},
+		expected: Presubmits{
+			"org/source-repo":      {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-source-repo"}}},
+			"org/destination-repo": {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-destination-repo"}}},
+		},
+	}, {
+		description: "merge jobs with same name for a single repo, result has the one originally in destination",
+		source: Presubmits{"org/repo": {
+			prowconfig.Presubmit{
+				JobBase:   prowconfig.JobBase{Name: "same-job-for-org-repo"},
+				AlwaysRun: true,
+			},
+		}},
+		destination: Presubmits{"org/repo": {
+			prowconfig.Presubmit{
+				JobBase:   prowconfig.JobBase{Name: "same-job-for-org-repo"},
+				AlwaysRun: false,
+			}}},
+		expected: Presubmits{"org/repo": {
+			prowconfig.Presubmit{
+				JobBase:   prowconfig.JobBase{Name: "same-job-for-org-repo"},
+				AlwaysRun: false,
+			},
+		}},
+	},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.destination.AddAll(tc.source)
+
+			if !reflect.DeepEqual(tc.destination, tc.expected) {
+				t.Errorf("Presubmits differ from expected after AddAll:\n%s", diff.ObjectDiff(tc.expected, tc.destination))
+			}
+		})
+	}
+}
+
+func TestPresubmitsAdd(t *testing.T) {
+	testCases := []struct {
+		description string
+		presubmits  Presubmits
+		repo        string
+		job         prowconfig.Presubmit
+		expected    Presubmits
+	}{{
+		description: "add job to new repo",
+		presubmits:  Presubmits{},
+		repo:        "org/repo",
+		job:         prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "job-for-org-repo"}},
+		expected:    Presubmits{"org/repo": {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "job-for-org-repo"}}}},
+	},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.presubmits.Add(tc.repo, tc.job)
+
+			if !reflect.DeepEqual(tc.expected, tc.presubmits) {
+				t.Errorf("Presubmits differ from expected after Add:\n%s", diff.ObjectDiff(tc.expected, tc.presubmits))
+			}
+		})
+	}
+
+}

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -22,6 +22,8 @@ const (
 	CiopConfigInRepoPath = "ci-operator/config"
 	// TemplatesPath is the path of the templates from release repo
 	TemplatesPath = "ci-operator/templates"
+	// Name of the configmap that stores all ci-operator configs
+	CiOperatorConfigsCMName = "ci-operator-configs"
 )
 
 // ReleaseRepoConfig contains all configuration present in release repo (usually openshift/release)

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -63,8 +63,8 @@ func GetChangedCiopConfigs(masterConfig, prConfig config.CompoundCiopConfig, log
 }
 
 // GetChangedPresubmits returns a mapping of repo to presubmits to execute.
-func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, logger *logrus.Entry) map[string][]prowconfig.Presubmit {
-	ret := make(map[string][]prowconfig.Presubmit)
+func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, logger *logrus.Entry) config.Presubmits {
+	ret := config.Presubmits{}
 
 	masterJobs := getJobsByRepoAndName(prowMasterConfig.JobConfig.Presubmits)
 	for repo, jobs := range prowPRConfig.JobConfig.Presubmits {
@@ -77,14 +77,14 @@ func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, log
 				if masterJob.Agent != job.Agent {
 					logFields[logDiffs] = convertToReadableDiff(masterJob.Agent, job.Agent, objectAgent)
 					logger.WithFields(logFields).Info(chosenJob)
-					ret[repo] = append(ret[repo], job)
+					ret.Add(repo, job)
 					continue
 				}
 
 				if !equality.Semantic.DeepEqual(masterJob.Spec, job.Spec) {
 					logFields[logDiffs] = convertToReadableDiff(masterJob.Spec, job.Spec, objectSpec)
 					logger.WithFields(logFields).Info(chosenJob)
-					ret[repo] = append(ret[repo], job)
+					ret.Add(repo, job)
 				}
 			}
 		}
@@ -96,7 +96,7 @@ func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, log
 // and compare the same key and index of the other map of slices,
 // we convert them as `repo-> jobName-> Presubmit` to be able to
 // access any specific elements of the Presubmits without the need to iterate in slices.
-func getJobsByRepoAndName(presubmits map[string][]prowconfig.Presubmit) map[string]map[string]prowconfig.Presubmit {
+func getJobsByRepoAndName(presubmits config.Presubmits) map[string]map[string]prowconfig.Presubmit {
 	jobsByRepo := make(map[string]map[string]prowconfig.Presubmit)
 
 	for repo, preSubmitList := range presubmits {

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 
+	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	templateapi "github.com/openshift/api/template/v1"
@@ -394,5 +395,107 @@ func makeBaseTemplates(baseParameters []templateapi.Parameter, baseObjects []run
 			Parameters: baseParameters,
 			Objects:    baseObjects,
 		},
+	}
+}
+
+func TestGetPresubmitsForCiopConfigs(t *testing.T) {
+	basePresubmitWithCiop := prowconfig.Presubmit{
+		JobBase: prowconfig.JobBase{
+			Agent: string(pjapi.KubernetesAgent),
+			Spec: &v1.PodSpec{
+				Containers: []v1.Container{{
+					Env: []v1.EnvVar{{
+						ValueFrom: &v1.EnvVarSource{
+							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: config.CiOperatorConfigsCMName,
+								},
+							},
+						},
+					}},
+				}},
+			},
+		},
+	}
+
+	testCases := []struct {
+		description string
+		prow        *prowconfig.Config
+		ciop        config.CompoundCiopConfig
+		expected    config.Presubmits
+	}{{
+		description: "return a presubmit using one of the input ciop configs",
+		prow: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						func() prowconfig.Presubmit {
+							ret := prowconfig.Presubmit{}
+							deepcopy.Copy(&ret, &basePresubmitWithCiop)
+							ret.Name = "job-for-org-repo"
+							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = "org-repo-branch.yaml"
+							return ret
+						}(),
+					}},
+			},
+		},
+		ciop: config.CompoundCiopConfig{"org-repo-branch.yaml": &cioperatorapi.ReleaseBuildConfiguration{}},
+		expected: config.Presubmits{"org/repo": {
+			func() prowconfig.Presubmit {
+				ret := prowconfig.Presubmit{}
+				deepcopy.Copy(&ret, &basePresubmitWithCiop)
+				ret.Name = "job-for-org-repo"
+				ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = "org-repo-branch.yaml"
+				return ret
+			}(),
+		}},
+	}, {
+		description: "do not return a presubmit using a ciop config not present in input",
+		prow: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						func() prowconfig.Presubmit {
+							ret := prowconfig.Presubmit{}
+							deepcopy.Copy(&ret, &basePresubmitWithCiop)
+							ret.Name = "job-for-org-repo"
+							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = "org-repo-branch.yaml"
+							return ret
+						}(),
+					}},
+			},
+		},
+		ciop:     config.CompoundCiopConfig{},
+		expected: config.Presubmits{},
+	}, {
+		description: "handle jenkins presubmits",
+		prow: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						func() prowconfig.Presubmit {
+							ret := prowconfig.Presubmit{}
+							deepcopy.Copy(&ret, &basePresubmitWithCiop)
+							ret.Name = "job-for-org-repo"
+							ret.Agent = string(pjapi.JenkinsAgent)
+							ret.Spec.Containers[0].Env = []v1.EnvVar{}
+							return ret
+						}(),
+					}},
+			},
+		},
+		ciop:     config.CompoundCiopConfig{},
+		expected: config.Presubmits{},
+	},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			presubmits := GetPresubmitsForCiopConfigs(tc.prow, tc.ciop, logrus.NewEntry(logrus.New()))
+
+			if !reflect.DeepEqual(tc.expected, presubmits) {
+				t.Errorf("Returned presubmits differ from expected:\n%s", diff.ObjectDiff(tc.expected, presubmits))
+			}
+		})
 	}
 }

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -111,14 +111,14 @@ func TestGetChangedPresubmits(t *testing.T) {
 	testCases := []struct {
 		name            string
 		configGenerator func() (before, after *prowconfig.Config)
-		expected        map[string][]prowconfig.Presubmit
+		expected        config.Presubmits
 	}{
 		{
 			name: "no differences mean nothing is identified as a diff",
 			configGenerator: func() (*prowconfig.Config, *prowconfig.Config) {
 				return makeConfig(basePresubmit), makeConfig(basePresubmit)
 			},
-			expected: map[string][]prowconfig.Presubmit{},
+			expected: config.Presubmits{},
 		},
 		{
 			name: "new job added",
@@ -134,7 +134,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 				return makeConfig(basePresubmit), makeConfig(p)
 
 			},
-			expected: map[string][]prowconfig.Presubmit{
+			expected: config.Presubmits{
 				"org/repo": func() []prowconfig.Presubmit {
 					var p []prowconfig.Presubmit
 					var pNew prowconfig.Presubmit
@@ -155,7 +155,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 				return makeConfig(p), makeConfig(basePresubmit)
 
 			},
-			expected: map[string][]prowconfig.Presubmit{
+			expected: config.Presubmits{
 				"org/repo": basePresubmit,
 			},
 		},
@@ -168,7 +168,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 				return makeConfig(basePresubmit), makeConfig(p)
 
 			},
-			expected: map[string][]prowconfig.Presubmit{
+			expected: config.Presubmits{
 				"org/repo": func() []prowconfig.Presubmit {
 					var p []prowconfig.Presubmit
 					deepcopy.Copy(&p, basePresubmit)
@@ -192,7 +192,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 				}
 				return makeConfig(basePresubmit), makeConfig(p)
 			},
-			expected: map[string][]prowconfig.Presubmit{
+			expected: config.Presubmits{
 				"org/repo": func() []prowconfig.Presubmit {
 					var p []prowconfig.Presubmit
 					deepcopy.Copy(&p, basePresubmit)
@@ -223,7 +223,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 func makeConfig(p []prowconfig.Presubmit) *prowconfig.Config {
 	return &prowconfig.Config{
 		JobConfig: prowconfig.JobConfig{
-			Presubmits: map[string][]prowconfig.Presubmit{"org/repo": p},
+			Presubmits: config.Presubmits{"org/repo": p},
 		},
 	}
 }

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -78,8 +78,8 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	return &rehearsal, nil
 }
 
-func filterJobs(changedPresubmits map[string][]prowconfig.Presubmit, allowVolumes bool, logger logrus.FieldLogger) map[string][]prowconfig.Presubmit {
-	ret := make(map[string][]prowconfig.Presubmit)
+func filterJobs(changedPresubmits map[string][]prowconfig.Presubmit, allowVolumes bool, logger logrus.FieldLogger) config.Presubmits {
+	ret := config.Presubmits{}
 	for repo, jobs := range changedPresubmits {
 		for _, job := range jobs {
 			jobLogger := logger.WithFields(logrus.Fields{"repo": repo, "job": job.Name})
@@ -87,7 +87,7 @@ func filterJobs(changedPresubmits map[string][]prowconfig.Presubmit, allowVolume
 				jobLogger.WithError(err).Warn("could not rehearse job")
 				continue
 			}
-			ret[repo] = append(ret[repo], job)
+			ret.Add(repo, job)
 		}
 	}
 	return ret
@@ -166,7 +166,7 @@ func inlineCiOpConfig(job *prowconfig.Presubmit, targetRepo string, ciopConfigs 
 
 // ConfigureRehearsalJobs filters the jobs that should be rehearsed, then return a list of them re-configured with the
 // ci-operator's configuration inlined.
-func ConfigureRehearsalJobs(toBeRehearsed map[string][]prowconfig.Presubmit, ciopConfigs config.CompoundCiopConfig, prNumber int, loggers Loggers, allowVolumes bool) []*prowconfig.Presubmit {
+func ConfigureRehearsalJobs(toBeRehearsed config.Presubmits, ciopConfigs config.CompoundCiopConfig, prNumber int, loggers Loggers, allowVolumes bool) []*prowconfig.Presubmit {
 	rehearsals := []*prowconfig.Presubmit{}
 
 	rehearsalsFiltered := filterJobs(toBeRehearsed, allowVolumes, loggers.Job)

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -30,8 +30,6 @@ import (
 const (
 	rehearseLabel                = "ci.openshift.org/rehearse"
 	defaultRehearsalRerunCommand = "/test pj-rehearse"
-	ciOperatorConfigsCMName      = "ci-operator-configs"
-	ciopConfigsInRepo            = "ci-operator/config"
 	logRehearsalJob              = "rehearsal-job"
 	logCiopConfigFile            = "ciop-config-file"
 	logCiopConfigRepo            = "ciop-config-repo"
@@ -138,7 +136,7 @@ func inlineCiOpConfig(job *prowconfig.Presubmit, targetRepo string, ciopConfigs 
 			if env.ValueFrom.ConfigMapKeyRef == nil {
 				continue
 			}
-			if env.ValueFrom.ConfigMapKeyRef.Name == ciOperatorConfigsCMName {
+			if env.ValueFrom.ConfigMapKeyRef.Name == config.CiOperatorConfigsCMName {
 				filename := env.ValueFrom.ConfigMapKeyRef.Key
 
 				logFields := logrus.Fields{logCiopConfigFile: filename, logCiopConfigRepo: targetRepo, logRehearsalJob: job.Name}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -89,12 +89,12 @@ func TestInlineCiopConfig(t *testing.T) {
 		expectedEnv: []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference("test-cm", "key")}},
 	}, {
 		description: "CM reference to ci-operator-configs -> cm content inlined",
-		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(ciOperatorConfigsCMName, "filename")}},
+		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(config.CiOperatorConfigsCMName, "filename")}},
 		configs:     config.CompoundCiopConfig{"filename": testCiopConfig},
 		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopCongigContent)}},
 	}, {
 		description:   "bad CM key is handled",
-		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(ciOperatorConfigsCMName, "filename")}},
+		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(config.CiOperatorConfigsCMName, "filename")}},
 		configs:       config.CompoundCiopConfig{},
 		expectedError: true,
 	},

--- a/test/pj-rehearse-integration/expected_jobs.yaml
+++ b/test/pj-rehearse-integration/expected_jobs.yaml
@@ -2,6 +2,106 @@
   kind: ProwJob
   metadata:
     annotations:
+      prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
+    creationTimestamp: null
+    labels:
+      ci.openshift.org/rehearse: "1234"
+      created-by-prow: "true"
+      prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
+      prow.k8s.io/refs.org: openshift
+      prow.k8s.io/refs.pull: "1234"
+      prow.k8s.io/refs.repo: release
+      prow.k8s.io/type: presubmit
+    name: 9bdfbae2-405b-11e9-ac33-74d435fb2dc0
+    namespace: test-namespace
+  spec:
+    agent: kubernetes
+    cluster: default
+    context: ci/rehearse/super/duper/ciop-cfg-change/images
+    decoration_config:
+      gcs_configuration:
+        bucket: origin-ci-test
+        default_org: openshift
+        default_repo: origin
+        path_strategy: single
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+      grace_period: 15000000000
+      skip_cloning: true
+      timeout: 14400000000000
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+        initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+        sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+    job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
+    namespace: test-namespace
+    pod_spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --give-pr-author-access-to-namespace=true
+        - --target=[images]
+        - --target=[release:latest]
+        - --git-ref=super/duper@ciop-cfg-change
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          value: |
+            base_images:
+              base:
+                cluster: https://api.ci.openshift.org
+                name: origin-v4.0
+                namespace: openshift
+                tag: base
+            build_root:
+              image_stream_tag:
+                cluster: https://api.ci.openshift.org
+                name: release
+                namespace: openshift
+                tag: golang-1.10
+            canonical_go_repository: ""
+            images:
+            - from: base
+              to: test-image
+            - from: base
+              to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
+            resources:
+              '*':
+                limits:
+                  cpu: 500Mi
+                requests:
+                  cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    refs:
+      base_ref: master
+      base_sha: 328cef7c6235073b55754d503b98c9233eaa9955
+      org: openshift
+      pulls:
+      - author: petr-muller
+        number: 1234
+        sha: 2a4d89d759b611ad3f423378c7d78f3af15d78e2
+      repo: release
+    report: true
+    rerun_command: /test pj-rehearse
+    type: presubmit
+  status:
+    startTime: "2019-03-06T22:03:01Z"
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-master-cmd
     creationTimestamp: null
     labels:


### PR DESCRIPTION
Post-https://github.com/openshift/ci-operator-prowgen/pull/96, we are able to detect which ci-operator configs changed in a PR. To start rehearsing the jobs affected by changed ci-operator configs, we needed to implement these two remaining capabilities:

1. Walk through all presubmits and find which ones reference one of the changed configs
2. Merge the two discovered sets of rehearsal jobs without creating duplicates.

/cc @stevekuznetsov @bbguimaraes @droslean 