### PR TITLE
Better diff output on tests.

### DIFF
--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -84,7 +84,7 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 			expected := tc.expected()
 
 			if !reflect.DeepEqual(expected, actual) {
-				t.Errorf("Detected changed ci-operator config changes differ from expected:\n%s", diff.ObjectDiff(expected, actual))
+				t.Errorf("Detected changed ci-operator config changes differ from expected:\n%s", diff.ObjectReflectDiff(expected, actual))
 			}
 		})
 	}

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -218,7 +218,7 @@ func TestMergeJobConfig(t *testing.T) {
 		mergeJobConfig(tc.destination, tc.source, tc.allJobs)
 
 		if !equality.Semantic.DeepEqual(tc.destination, tc.expected) {
-			t.Errorf("expected merged job config diff:\n%s", diff.ObjectDiff(tc.expected, tc.destination))
+			t.Errorf("expected merged job config diff:\n%s", diff.ObjectReflectDiff(tc.expected, tc.destination))
 		}
 	}
 }
@@ -386,7 +386,7 @@ func TestMergePresubmits(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if actual, expected := mergePresubmits(testCase.old, testCase.new), testCase.expected; !equality.Semantic.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get expected merged presubmit config:\n%s", testCase.name, diff.ObjectDiff(actual, expected))
+				t.Errorf("%s: did not get expected merged presubmit config:\n%s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 		})
 	}
@@ -487,7 +487,7 @@ func TestMergePostsubmits(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if actual, expected := mergePostsubmits(testCase.old, testCase.new), testCase.expected; !equality.Semantic.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get expected merged postsubmit config:\n%s", testCase.name, diff.ObjectDiff(actual, expected))
+				t.Errorf("%s: did not get expected merged postsubmit config:\n%s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 		})
 	}
@@ -547,7 +547,7 @@ func TestExtractRepoElementsFromPath(t *testing.T) {
 				t.Errorf("%s: expected no error, but got one: %v", testCase.name, err)
 			}
 			if actual, expected := elements, testCase.expected; !equality.Semantic.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get expected repo info from path:\n%s", testCase.name, diff.ObjectDiff(actual, expected))
+				t.Errorf("%s: did not get expected repo info from path:\n%s", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 		})
 	}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -120,7 +120,7 @@ func TestInlineCiopConfig(t *testing.T) {
 				}
 
 				if !equality.Semantic.DeepEqual(expectedJob, newJob) {
-					t.Errorf("Returned job differs from expected:\n%s", diff.ObjectDiff(expectedJob, newJob))
+					t.Errorf("Returned job differs from expected:\n%s", diff.ObjectReflectDiff(expectedJob, newJob))
 				}
 			}
 		})
@@ -181,7 +181,7 @@ func TestMakeRehearsalPresubmit(t *testing.T) {
 		t.Errorf("Unexpected error in makeRehearsalPresubmit: %v", err)
 	}
 	if !equality.Semantic.DeepEqual(expectedPresubmit, rehearsal) {
-		t.Errorf("Expected rehearsal Presubmit differs:\n%s", diff.ObjectDiff(expectedPresubmit, rehearsal))
+		t.Errorf("Expected rehearsal Presubmit differs:\n%s", diff.ObjectReflectDiff(expectedPresubmit, rehearsal))
 	}
 }
 
@@ -501,7 +501,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 			sort.Slice(createdJobSpecs, func(a, b int) bool { return createdJobSpecs[a].Job < createdJobSpecs[b].Job })
 
 			if !equality.Semantic.DeepEqual(tc.expectedJobs, createdJobSpecs) {
-				t.Errorf("Created ProwJobs differ from expected:\n%s", diff.ObjectDiff(tc.expectedJobs, createdJobSpecs))
+				t.Errorf("Created ProwJobs differ from expected:\n%s", diff.ObjectReflectDiff(tc.expectedJobs, createdJobSpecs))
 			}
 		})
 	}


### PR DESCRIPTION
`ObjectReflectDiff` creates a more human-readable diff for the objects.