### PR TITLE
 Handle sharded ci-operator CMs in rehearse

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -56,6 +57,11 @@ func (i *Info) Basename() string {
 // ConfigMapName returns the configmap in which we expect this file to be uploaded
 func (i *Info) ConfigMapName() string {
 	return fmt.Sprintf("ci-operator-%s-configs", promotion.FlavorForBranch(i.Branch))
+}
+
+// IsCiopConfigCM returns true if a given name is a valid ci-operator config ConfigMap
+func IsCiopConfigCM(name string) bool {
+	return regexp.MustCompile(`^ci-operator-.+-configs$`).MatchString(name)
 }
 
 // We use the directory/file naming convention to encode useful information

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -190,8 +190,13 @@ func TestInfo_ConfigMapName(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.expected, func(t *testing.T) {
 			info := Info{Branch: testCase.branch}
-			if actual, expected := info.ConfigMapName(), testCase.expected; !reflect.DeepEqual(actual, expected) {
+			actual, expected := info.ConfigMapName(), testCase.expected
+			if !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+			// test that ConfigMapName() stays in sync with IsCiopConfigCM()
+			if !IsCiopConfigCM(actual) {
+				t.Errorf("%s: IsCiopConfigCM() returned false for %s", testCase.name, actual)
 			}
 		})
 	}

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -22,8 +22,6 @@ const (
 	CiopConfigInRepoPath = "ci-operator/config"
 	// TemplatesPath is the path of the templates from release repo
 	TemplatesPath = "ci-operator/templates"
-	// Name of the configmap that stores all ci-operator configs
-	CiOperatorConfigsCMName = "ci-operator-configs"
 )
 
 // ReleaseRepoConfig contains all configuration present in release repo (usually openshift/release)

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -166,7 +166,7 @@ func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs conf
 				if env.ValueFrom.ConfigMapKeyRef == nil {
 					continue
 				}
-				if env.ValueFrom.ConfigMapKeyRef.Name == config.CiOperatorConfigsCMName {
+				if config.IsCiopConfigCM(env.ValueFrom.ConfigMapKeyRef.Name) {
 					if _, ok := ciopConfigs[env.ValueFrom.ConfigMapKeyRef.Key]; ok {
 						ret.Add(repo, job)
 					}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -399,6 +399,13 @@ func makeBaseTemplates(baseParameters []templateapi.Parameter, baseObjects []run
 }
 
 func TestGetPresubmitsForCiopConfigs(t *testing.T) {
+	baseCiopConfig := config.Info{
+		Org:      "org",
+		Repo:     "repo",
+		Branch:   "branch",
+		Filename: "org-repo-branch.yaml",
+	}
+
 	basePresubmitWithCiop := prowconfig.Presubmit{
 		JobBase: prowconfig.JobBase{
 			Agent: string(pjapi.KubernetesAgent),
@@ -408,7 +415,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 						ValueFrom: &v1.EnvVarSource{
 							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
 								LocalObjectReference: v1.LocalObjectReference{
-									Name: config.CiOperatorConfigsCMName,
+									Name: baseCiopConfig.ConfigMapName(),
 								},
 							},
 						},
@@ -433,19 +440,19 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 							ret := prowconfig.Presubmit{}
 							deepcopy.Copy(&ret, &basePresubmitWithCiop)
 							ret.Name = "job-for-org-repo"
-							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = "org-repo-branch.yaml"
+							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 							return ret
 						}(),
 					}},
 			},
 		},
-		ciop: config.CompoundCiopConfig{"org-repo-branch.yaml": &cioperatorapi.ReleaseBuildConfiguration{}},
+		ciop: config.CompoundCiopConfig{baseCiopConfig.Filename: &cioperatorapi.ReleaseBuildConfiguration{}},
 		expected: config.Presubmits{"org/repo": {
 			func() prowconfig.Presubmit {
 				ret := prowconfig.Presubmit{}
 				deepcopy.Copy(&ret, &basePresubmitWithCiop)
 				ret.Name = "job-for-org-repo"
-				ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = "org-repo-branch.yaml"
+				ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 				return ret
 			}(),
 		}},
@@ -459,7 +466,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 							ret := prowconfig.Presubmit{}
 							deepcopy.Copy(&ret, &basePresubmitWithCiop)
 							ret.Name = "job-for-org-repo"
-							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = "org-repo-branch.yaml"
+							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 							return ret
 						}(),
 					}},

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -136,7 +136,7 @@ func inlineCiOpConfig(job *prowconfig.Presubmit, targetRepo string, ciopConfigs 
 			if env.ValueFrom.ConfigMapKeyRef == nil {
 				continue
 			}
-			if env.ValueFrom.ConfigMapKeyRef.Name == config.CiOperatorConfigsCMName {
+			if config.IsCiopConfigCM(env.ValueFrom.ConfigMapKeyRef.Name) {
 				filename := env.ValueFrom.ConfigMapKeyRef.Key
 
 				logFields := logrus.Fields{logCiopConfigFile: filename, logCiopConfigRepo: targetRepo, logRehearsalJob: job.Name}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -57,6 +57,11 @@ func makeCMReference(cmName, key string) *v1.EnvVarSource {
 
 func TestInlineCiopConfig(t *testing.T) {
 	testTargetRepo := "org/repo"
+	testCiopConfigInfo := config.Info{
+		Org:    "org",
+		Repo:   "repo",
+		Branch: "master",
+	}
 	testCiopConfig := &api.ReleaseBuildConfiguration{}
 	testCiopCongigContent, err := yaml.Marshal(testCiopConfig)
 	if err != nil {
@@ -89,12 +94,12 @@ func TestInlineCiopConfig(t *testing.T) {
 		expectedEnv: []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference("test-cm", "key")}},
 	}, {
 		description: "CM reference to ci-operator-configs -> cm content inlined",
-		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(config.CiOperatorConfigsCMName, "filename")}},
+		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
 		configs:     config.CompoundCiopConfig{"filename": testCiopConfig},
 		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopCongigContent)}},
 	}, {
 		description:   "bad CM key is handled",
-		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(config.CiOperatorConfigsCMName, "filename")}},
+		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
 		configs:       config.CompoundCiopConfig{},
 		expectedError: true,
 	},

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -16,7 +16,6 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         env:
@@ -24,7 +23,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-ciop-cfg-change.yaml
-              name: ci-operator-configs
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -61,7 +61,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -107,7 +107,6 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         env:
@@ -115,17 +114,15 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -149,7 +146,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -183,7 +180,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -61,7 +61,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -107,7 +107,6 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         env:
@@ -115,17 +114,15 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 1500m
           requests:
-            cpu: 10m
+            cpu: 10000000000m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -149,7 +146,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -183,7 +180,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/expected_jobs.yaml
+++ b/test/pj-rehearse-integration/expected_jobs.yaml
@@ -41,7 +41,6 @@
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         - --git-ref=super/duper@ciop-cfg-change
         command:
         - ci-operator
@@ -435,7 +434,6 @@
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         - --git-ref=super/trooper@master
         command:
         - ci-operator
@@ -471,10 +469,8 @@
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 1500m
           requests:
-            cpu: 10m
+            cpu: 10M
       serviceAccountName: ci-operator
     refs:
       base_ref: master

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -16,7 +16,6 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         env:
@@ -24,7 +23,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-ciop-cfg-change.yaml
-              name: ci-operator-configs
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -61,7 +61,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -107,7 +107,6 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         env:
@@ -115,17 +114,15 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -149,7 +146,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -183,7 +180,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -61,7 +61,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -107,7 +107,6 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --give-pr-author-access-to-namespace=true
         - --target=[images]
-        - --target=[release:latest]
         command:
         - ci-operator
         env:
@@ -115,17 +114,15 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
         resources:
-          limits:
-            cpu: 500m
           requests:
             cpu: 10m
       serviceAccountName: ci-operator
-    trigger: ((?m)^/test( all| images),?(\s+|$))
+    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
   - agent: kubernetes
     always_run: true
     branches:
@@ -149,7 +146,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -183,7 +180,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-trooper-master.yaml
-              name: ci-operator-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
Previously, rehearse assumed all ci-operator configs live in a single
CM, called `ci-operator-configs`. After openshift/release [PR#3009](https://github.com/openshift/release/pull/3009), this
is no longer true, so the two places that work with ci-operator configs
(change detection and ciop config inlining) need to be adjusted.

Builds on https://github.com/openshift/ci-operator-prowgen/pull/101