### PR TITLE
in --local, create a PR number seeding from current time

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -136,6 +137,9 @@ func rehearseMain() int {
 	}
 
 	prNumber := jobSpec.Refs.Pulls[0].Number
+	if o.local {
+		prNumber = int(time.Now().Unix())
+	}
 	logger = logrus.WithField(prowgithub.PrLogField, prNumber)
 	logger.Info("Rehearsing Prow jobs for a configuration PR")
 


### PR DESCRIPTION
When the users are running the `pj-rehearse` tool with `--local`, creates a PR number instead of `0`. 
This change will make sure that the temporary configmaps won't all be deleted when multiple users are running with `--local`