### PR TITLE
no need to configure template.Name.

### DIFF
--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -51,10 +50,6 @@ func getTemplates(templatePath string) (CiTemplates, error) {
 
 			if obj, _, err := templatescheme.Codecs.UniversalDeserializer().Decode(contents, nil, nil); err == nil {
 				if template, ok := obj.(*templateapi.Template); ok {
-					if len(template.Name) == 0 {
-						template.Name = filepath.Base(path)
-						template.Name = strings.TrimSuffix(template.Name, filepath.Ext(template.Name))
-					}
 					templates[filepath.Base(path)] = template
 				}
 			}

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 
 	templateapi "github.com/openshift/api/template/v1"
@@ -115,10 +114,6 @@ func getBaseCiTemplates(t *testing.T) CiTemplates {
 	var expectedTemplate *templateapi.Template
 	if obj, _, err := templatescheme.Codecs.UniversalDeserializer().Decode(contents, nil, nil); err == nil {
 		if template, ok := obj.(*templateapi.Template); ok {
-			if len(template.Name) == 0 {
-				template.Name = filepath.Base(testTemplatePath)
-				template.Name = strings.TrimSuffix(template.Name, filepath.Ext(template.Name))
-			}
 			expectedTemplate = template
 		}
 	}


### PR DESCRIPTION
That is causing errors like [this](https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_release/3132/rehearse-3132-pull-ci-openshift-console-master-e2e-aws-console/11)

ci-operator is generating the name depending on the filename already, and the file is mounted with a different name. 
So, if we configure a `template.Name` already, `ci-operator` will use that one instead. see [here](https://github.com/openshift/ci-operator/blob/master/cmd/ci-operator/main.go#L353-L361)