### PR TITLE
Add a script to validate Prowgen changes do not break openshift/release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,7 @@ integration-prowgen:
 integration-pj-rehearse:
 	test/pj-rehearse-integration/run.sh
 .PHONY: integration-pj-rehearse
+
+check-breaking-changes:
+	test/validate-prowgen-breaking-changes.sh
+.PHONY: check-breaking-changes

--- a/test/validate-prowgen-breaking-changes.sh
+++ b/test/validate-prowgen-breaking-changes.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+workdir="$( mktemp -d )"
+trap 'rm -rf "${workdir}"' EXIT
+
+git clone https://github.com/openshift/release.git --depth 1 "${workdir}/release"
+
+ci-operator-prowgen --from-dir "${workdir}/release/ci-operator/config" --to-dir "${workdir}/release/ci-operator/jobs"
+
+pushd "${workdir}/release"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "[ERROR] Changes in openshift/release:"
+  git diff
+  echo "[ERROR] Running Prowgen in openshift/release results in changes ^^^"
+  echo "[ERROR] To avoid breaking openshift/release for everyone you should regenerate"
+  echo "[ERROR] the jobs there and merge the changes ASAP after this change to Prowgen"
+else
+  echo "Running Prowgen in openshift/release does not result in changes, no followups needed"
+fi
+
+popd


### PR DESCRIPTION
I was using a similar script for a while so I thought why not polish it a bit and make a presubmit out of it. This would remind us to always prepare followup PRs to `openshift/release` repo when we change Prowgen.