### PR TITLE
Improve job selection on changed ci-op configs

### DIFF
--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -157,8 +157,8 @@ func getRehersalsHelper(logger *logrus.Entry, prNumber int) ([]*prowconfig.Presu
 		return nil, fmt.Errorf("Empty changedPresubmits was not expected")
 	}
 
-	changedCiopConfigs := diffs.GetChangedCiopConfigs(ciopMasterConfig, ciopPrConfig, logger)
-	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger))
+	changedCiopConfigs, _ := diffs.GetChangedCiopConfigs(ciopMasterConfig, ciopPrConfig, logger)
+	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger, nil))
 
 	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, nil)
 

--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -157,8 +157,8 @@ func getRehersalsHelper(logger *logrus.Entry, prNumber int) ([]*prowconfig.Presu
 		return nil, fmt.Errorf("Empty changedPresubmits was not expected")
 	}
 
-	changedCiopConfigs, _ := diffs.GetChangedCiopConfigs(ciopMasterConfig, ciopPrConfig, logger)
-	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger, nil))
+	changedCiopConfigs, affectedJobs := diffs.GetChangedCiopConfigs(ciopMasterConfig, ciopPrConfig, logger)
+	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger, affectedJobs))
 
 	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, nil)
 

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -191,9 +191,9 @@ func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs conf
 				}
 				if config.IsCiopConfigCM(env.ValueFrom.ConfigMapKeyRef.Name) {
 					if _, ok := ciopConfigs[env.ValueFrom.ConfigMapKeyRef.Key]; ok {
-
-						s := strings.Split(job.Name, "-")
-						testName := s[len(s)-1]
+						testName := strings.TrimPrefix(job.Name, "pull-ci-")
+						orgRepo := strings.Replace(repo, "/", "-", -1)
+						testName = strings.TrimPrefix(testName, fmt.Sprintf("%s-%s-", orgRepo, job.Brancher.Branches[0]))
 
 						affectedJob, ok := affectedJobs[env.ValueFrom.ConfigMapKeyRef.Key]
 						if ok && !affectedJob.Has(testName) {

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -8,9 +8,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	utildiff "k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
+
+	cioperatorapi "github.com/openshift/ci-operator/pkg/api"
 
 	"github.com/openshift/ci-operator-prowgen/pkg/config"
 )
@@ -38,11 +41,13 @@ const (
 	changedCiopConfigMsg = "ci-operator config file changed"
 )
 
-func GetChangedCiopConfigs(masterConfig, prConfig config.CompoundCiopConfig, logger *logrus.Entry) config.CompoundCiopConfig {
+func GetChangedCiopConfigs(masterConfig, prConfig config.CompoundCiopConfig, logger *logrus.Entry) (config.CompoundCiopConfig, map[string]sets.String) {
 	ret := config.CompoundCiopConfig{}
+	affectedJobs := map[string]sets.String{}
 
 	for filename, newConfig := range prConfig {
 		oldConfig, ok := masterConfig[filename]
+		jobs := sets.NewString()
 
 		// new ciop config
 		if !ok {
@@ -51,13 +56,33 @@ func GetChangedCiopConfigs(masterConfig, prConfig config.CompoundCiopConfig, log
 			continue
 		}
 
-		if !equality.Semantic.DeepEqual(oldConfig, newConfig) {
+		withoutTestsOldConfig := *masterConfig[filename]
+		withoutTestsOldConfig.Tests = nil
+		withoutTestsNewConfig := *prConfig[filename]
+		withoutTestsNewConfig.Tests = nil
+
+		if !equality.Semantic.DeepEqual(withoutTestsOldConfig, withoutTestsNewConfig) {
 			logger.WithField(logCiopConfig, filename).Info(changedCiopConfigMsg)
 			ret[filename] = newConfig
+			continue
+		}
+
+		oldTests := getTestsByName(oldConfig.Tests)
+		newTests := getTestsByName(newConfig.Tests)
+
+		for as, test := range newTests {
+			if !equality.Semantic.DeepEqual(oldTests[as], test) {
+				logger.WithField(logCiopConfig, filename).Info(changedCiopConfigMsg)
+				ret[filename] = newConfig
+				jobs.Insert(as)
+			}
+		}
+
+		if len(jobs) > 0 {
+			affectedJobs[filename] = jobs
 		}
 	}
-
-	return ret
+	return ret, affectedJobs
 }
 
 // GetChangedPresubmits returns a mapping of repo to presubmits to execute.
@@ -149,7 +174,7 @@ func GetChangedTemplates(masterTemplates, prTemplates config.CiTemplates, logger
 	return changedTemplates
 }
 
-func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs config.CompoundCiopConfig, logger *logrus.Entry) config.Presubmits {
+func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs config.CompoundCiopConfig, logger *logrus.Entry, affectedJobs map[string]sets.String) config.Presubmits {
 	ret := config.Presubmits{}
 
 	for repo, jobs := range prowConfig.JobConfig.Presubmits {
@@ -166,6 +191,15 @@ func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs conf
 				}
 				if config.IsCiopConfigCM(env.ValueFrom.ConfigMapKeyRef.Name) {
 					if _, ok := ciopConfigs[env.ValueFrom.ConfigMapKeyRef.Key]; ok {
+
+						s := strings.Split(job.Name, "-")
+						testName := s[len(s)-1]
+
+						affectedJob, ok := affectedJobs[env.ValueFrom.ConfigMapKeyRef.Key]
+						if ok && !affectedJob.Has(testName) {
+							continue
+						}
+
 						ret.Add(repo, job)
 					}
 				}
@@ -173,5 +207,13 @@ func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs conf
 		}
 	}
 
+	return ret
+}
+
+func getTestsByName(tests []cioperatorapi.TestStepConfiguration) map[string]cioperatorapi.TestStepConfiguration {
+	ret := make(map[string]cioperatorapi.TestStepConfiguration)
+	for _, test := range tests {
+		ret[test.As] = test
+	}
 	return ret
 }

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -81,7 +81,7 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			before, after := tc.configGenerator()
-			actual := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
+			actual, _ := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
 			expected := tc.expected()
 
 			if !reflect.DeepEqual(expected, actual) {
@@ -498,7 +498,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			presubmits := GetPresubmitsForCiopConfigs(tc.prow, tc.ciop, logrus.NewEntry(logrus.New()))
+			presubmits := GetPresubmitsForCiopConfigs(tc.prow, tc.ciop, logrus.NewEntry(logrus.New()), nil)
 
 			if !reflect.DeepEqual(tc.expected, presubmits) {
 				t.Errorf("Returned presubmits differ from expected:\n%s", diff.ObjectDiff(tc.expected, presubmits))

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
@@ -33,12 +34,27 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 				Name:      "name",
 			},
 		},
+		Tests: []cioperatorapi.TestStepConfiguration{
+			{
+				As:       "unit",
+				Commands: "make unit",
+			},
+			{
+				As:       "e2e",
+				Commands: "make e2e",
+			},
+			{
+				As:       "verify",
+				Commands: "make verify",
+			},
+		},
 	}
 
 	testCases := []struct {
-		name            string
-		configGenerator func() (before, after config.CompoundCiopConfig)
-		expected        func() config.CompoundCiopConfig
+		name                 string
+		configGenerator      func() (before, after config.CompoundCiopConfig)
+		expected             func() config.CompoundCiopConfig
+		expectedAffectedJobs map[string]sets.String
 	}{{
 		name: "no changes",
 		configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
@@ -46,7 +62,8 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 			after := config.CompoundCiopConfig{"org-repo-branch.yaml": &baseCiopConfig}
 			return before, after
 		},
-		expected: func() config.CompoundCiopConfig { return config.CompoundCiopConfig{} },
+		expected:             func() config.CompoundCiopConfig { return config.CompoundCiopConfig{} },
+		expectedAffectedJobs: map[string]sets.String{},
 	}, {
 		name: "new config",
 		configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
@@ -60,6 +77,7 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 		expected: func() config.CompoundCiopConfig {
 			return config.CompoundCiopConfig{"org-repo-another-branch.yaml": &baseCiopConfig}
 		},
+		expectedAffectedJobs: map[string]sets.String{},
 	}, {
 		name: "changed config",
 		configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
@@ -76,16 +94,65 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 			expected.InputConfiguration.ReleaseTagConfiguration.Name = "another-name"
 			return config.CompoundCiopConfig{"org-repo-branch.yaml": &expected}
 		},
-	}}
+		expectedAffectedJobs: map[string]sets.String{},
+	},
+		{
+			name: "changed tests",
+			configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
+				before := config.CompoundCiopConfig{"org-repo-branch.yaml": &baseCiopConfig}
+				afterConfig := cioperatorapi.ReleaseBuildConfiguration{}
+				deepcopy.Copy(&afterConfig, baseCiopConfig)
+				afterConfig.Tests[0].Commands = "changed commands"
+				after := config.CompoundCiopConfig{"org-repo-branch.yaml": &afterConfig}
+				return before, after
+			},
+			expected: func() config.CompoundCiopConfig {
+				expected := cioperatorapi.ReleaseBuildConfiguration{}
+				deepcopy.Copy(&expected, baseCiopConfig)
+				expected.Tests[0].Commands = "changed commands"
+				return config.CompoundCiopConfig{"org-repo-branch.yaml": &expected}
+			},
+			expectedAffectedJobs: map[string]sets.String{"org-repo-branch.yaml": {"unit": sets.Empty{}}},
+		},
+		{
+			name: "changed multiple tests",
+			configGenerator: func() (config.CompoundCiopConfig, config.CompoundCiopConfig) {
+				before := config.CompoundCiopConfig{"org-repo-branch.yaml": &baseCiopConfig}
+				afterConfig := cioperatorapi.ReleaseBuildConfiguration{}
+				deepcopy.Copy(&afterConfig, baseCiopConfig)
+				afterConfig.Tests[0].Commands = "changed commands"
+				afterConfig.Tests[1].Commands = "changed commands"
+				after := config.CompoundCiopConfig{"org-repo-branch.yaml": &afterConfig}
+				return before, after
+			},
+			expected: func() config.CompoundCiopConfig {
+				expected := cioperatorapi.ReleaseBuildConfiguration{}
+				deepcopy.Copy(&expected, baseCiopConfig)
+				expected.Tests[0].Commands = "changed commands"
+				expected.Tests[1].Commands = "changed commands"
+				return config.CompoundCiopConfig{"org-repo-branch.yaml": &expected}
+			},
+			expectedAffectedJobs: map[string]sets.String{
+				"org-repo-branch.yaml": {
+					"unit": sets.Empty{},
+					"e2e":  sets.Empty{},
+				},
+			},
+		},
+	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			before, after := tc.configGenerator()
-			actual, _ := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
+			actual, affectedJobs := GetChangedCiopConfigs(before, after, logrus.NewEntry(logrus.New()))
 			expected := tc.expected()
 
 			if !reflect.DeepEqual(expected, actual) {
 				t.Errorf("Detected changed ci-operator config changes differ from expected:\n%s", diff.ObjectReflectDiff(expected, actual))
+			}
+
+			if !reflect.DeepEqual(tc.expectedAffectedJobs, affectedJobs) {
+				t.Errorf("Affected jobs differ from expected:\n%s", diff.ObjectReflectDiff(tc.expectedAffectedJobs, affectedJobs))
 			}
 		})
 	}
@@ -407,6 +474,9 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 	}
 
 	basePresubmitWithCiop := prowconfig.Presubmit{
+		Brancher: prowconfig.Brancher{
+			Branches: []string{baseCiopConfig.Branch},
+		},
 		JobBase: prowconfig.JobBase{
 			Agent: string(pjapi.KubernetesAgent),
 			Spec: &v1.PodSpec{
@@ -425,6 +495,12 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 		},
 	}
 
+	affectedJobs := map[string]sets.String{
+		"org-repo-branch.yaml": {
+			"testjob": sets.Empty{},
+		},
+	}
+
 	testCases := []struct {
 		description string
 		prow        *prowconfig.Config
@@ -439,7 +515,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 						func() prowconfig.Presubmit {
 							ret := prowconfig.Presubmit{}
 							deepcopy.Copy(&ret, &basePresubmitWithCiop)
-							ret.Name = "job-for-org-repo"
+							ret.Name = "org-repo-branch-testjob"
 							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 							return ret
 						}(),
@@ -451,7 +527,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 			func() prowconfig.Presubmit {
 				ret := prowconfig.Presubmit{}
 				deepcopy.Copy(&ret, &basePresubmitWithCiop)
-				ret.Name = "job-for-org-repo"
+				ret.Name = "org-repo-branch-testjob"
 				ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 				return ret
 			}(),
@@ -465,7 +541,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 						func() prowconfig.Presubmit {
 							ret := prowconfig.Presubmit{}
 							deepcopy.Copy(&ret, &basePresubmitWithCiop)
-							ret.Name = "job-for-org-repo"
+							ret.Name = "org-repo-branch-testjob"
 							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 							return ret
 						}(),
@@ -483,7 +559,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 						func() prowconfig.Presubmit {
 							ret := prowconfig.Presubmit{}
 							deepcopy.Copy(&ret, &basePresubmitWithCiop)
-							ret.Name = "job-for-org-repo"
+							ret.Name = "org-repo-branch-testjob"
 							ret.Agent = string(pjapi.JenkinsAgent)
 							ret.Spec.Containers[0].Env = []v1.EnvVar{}
 							return ret
@@ -498,7 +574,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			presubmits := GetPresubmitsForCiopConfigs(tc.prow, tc.ciop, logrus.NewEntry(logrus.New()), nil)
+			presubmits := GetPresubmitsForCiopConfigs(tc.prow, tc.ciop, logrus.NewEntry(logrus.New()), affectedJobs)
 
 			if !reflect.DeepEqual(tc.expected, presubmits) {
 				t.Errorf("Returned presubmits differ from expected:\n%s", diff.ObjectDiff(tc.expected, presubmits))

--- a/test/pj-rehearse-integration/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
@@ -24,3 +24,8 @@ resources:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tests:
+- as: unit
+  commands: make unit CHANGED
+  container:
+    from: src

--- a/test/pj-rehearse-integration/expected_jobs.yaml
+++ b/test/pj-rehearse-integration/expected_jobs.yaml
@@ -366,6 +366,11 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            tests:
+            - as: unit
+              commands: make unit CHANGED
+              container:
+                from: src
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -464,12 +469,120 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            tests:
+            - as: unit
+              commands: make unit CHANGED
+              container:
+                from: src
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
         resources:
           requests:
             cpu: 10M
+      serviceAccountName: ci-operator
+    refs:
+      base_ref: master
+      base_sha: a1e0de27c562d86647c901554094d12d7c358ba8
+      org: openshift
+      pulls:
+      - author: petr-muller
+        number: 1234
+        sha: 7c0b9788f819121ac637fa3f8a319d0bc2cda73e
+      repo: release
+    report: true
+    rerun_command: /test pj-rehearse
+    type: presubmit
+  status:
+    startTime: "2019-02-11T17:02:53Z"
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-unit
+    creationTimestamp: null
+    labels:
+      ci.openshift.org/rehearse: "1234"
+      created-by-prow: "true"
+      prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-unit
+      prow.k8s.io/refs.org: openshift
+      prow.k8s.io/refs.pull: "1234"
+      prow.k8s.io/refs.repo: release
+      prow.k8s.io/type: presubmit
+    name: 7216cd7e-4c84-11e9-996c-54e1ad07d68a
+    namespace: test-namespace
+  spec:
+    agent: kubernetes
+    cluster: default
+    context: ci/rehearse/super/trooper/master/unit
+    decoration_config:
+      gcs_configuration:
+        bucket: origin-ci-test
+        default_org: openshift
+        default_repo: origin
+        path_strategy: single
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+      grace_period: 15000000000
+      skip_cloning: true
+      timeout: 14400000000000
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+        initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+        sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+    job: rehearse-1234-pull-ci-super-trooper-master-unit
+    namespace: test-namespace
+    pod_spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --give-pr-author-access-to-namespace=true
+        - --target=unit
+        - --git-ref=super/trooper@master
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          value: |
+            base_images:
+              base:
+                cluster: https://api.ci.openshift.org
+                name: origin-v4.0
+                namespace: openshift
+                tag: base
+            build_root:
+              image_stream_tag:
+                cluster: https://api.ci.openshift.org
+                name: release
+                namespace: openshift
+                tag: golang-1.10
+            images:
+            - from: base
+              to: test-image
+            resources:
+              '*':
+                limits:
+                  cpu: 500Mi
+                requests:
+                  cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
+            tests:
+            - as: unit
+              commands: make unit CHANGED
+              container:
+                from: src
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 10m
       serviceAccountName: ci-operator
     refs:
       base_ref: master

--- a/test/pj-rehearse-integration/master/ci-operator/config/super/trooper/super-trooper-master.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/config/super/trooper/super-trooper-master.yaml
@@ -24,3 +24,8 @@ resources:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tests:
+- as: unit
+  commands: make unit
+  container:
+    from: src


### PR DESCRIPTION
If only the `.tests` field in ci-op config changes, rehearse the corresponding jobs. 
