### PR TITLE
rehearse: detect cluster profile changes

### DIFF
--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -160,7 +160,7 @@ func getRehersalsHelper(logger *logrus.Entry, prNumber int) ([]*prowconfig.Presu
 	changedCiopConfigs, affectedJobs := diffs.GetChangedCiopConfigs(ciopMasterConfig, ciopPrConfig, logger)
 	changedPresubmits.AddAll(diffs.GetPresubmitsForCiopConfigs(prowPRConfig, changedCiopConfigs, logger, affectedJobs))
 
-	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, nil)
+	rehearsals := rehearse.ConfigureRehearsalJobs(changedPresubmits, ciopPrConfig, prNumber, rehearse.Loggers{Job: logger, Debug: logger}, false, nil, []config.ClusterProfile{})
 
 	return rehearsals, nil
 }

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -31,15 +31,22 @@ type ReleaseRepoConfig struct {
 	Templates  CiTemplates
 }
 
-func revParse(repoPath string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"rev-parse"}, args...)...)
+func git(repoPath string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
 	cmd.Dir = repoPath
-	sha, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("'%s' failed with error=%v", cmd.Args, err)
+		return "", fmt.Errorf("'%s' failed with error=%v, output:\n%s", cmd.Args, err, out)
 	}
+	return string(out), nil
+}
 
-	return strings.TrimSpace(string(sha)), nil
+func revParse(repoPath string, args ...string) (string, error) {
+	out, err := git(repoPath, append([]string{"rev-parse"}, args...)...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func gitCheckout(candidatePath, baseSHA string) error {

--- a/pkg/config/release_test.go
+++ b/pkg/config/release_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGetChangedClusterProfiles(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	profilesPath := filepath.Join(dir, ClusterProfilesPath)
+	for _, f := range []string{
+		"nochanges/file", "changeme/file", "removeme/file", "moveme/file",
+		"renameme/file", "dir/dir/file",
+	} {
+		path := filepath.Join(dir, ClusterProfilesPath, f)
+		if err := os.MkdirAll(filepath.Dir(path), 0775); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile(path, []byte(f+"content"), 0664); err != nil {
+			t.Fatal(err)
+		}
+	}
+	p := exec.Command("sh", "-ec", fmt.Sprintf(`
+git init --quiet .
+git config user.name test
+git config user.email test
+git add .
+git commit --quiet -m initial
+cd %s
+> changeme/file
+git rm --quiet removeme/file
+mkdir new/ renamed/
+> new/file
+git add new/file
+git mv moveme/file moveme/moved
+git mv renameme/file renamed/file
+> dir/dir/file
+git commit --quiet -am changes
+git rev-parse HEAD^
+`, profilesPath))
+	p.Dir = dir
+	out, err := p.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%q failed, output:\n%s", p.Args, out)
+	}
+	changed, err := GetChangedClusterProfiles(dir, strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []ClusterProfile{
+		{Name: "changeme", TreeHash: "df2b8fc99e1c1d4dbc0a854d9f72157f1d6ea078"},
+		{Name: "dir", TreeHash: "b4c3cc91598b6469bf7036502b8ca2bd563b0d0a"},
+		{Name: "moveme", TreeHash: "03b9d461447abb84264053a440b4c715842566bb"},
+		{Name: "new", TreeHash: "df2b8fc99e1c1d4dbc0a854d9f72157f1d6ea078"},
+		{Name: "renamed", TreeHash: "9bbab5dcf83793f9edc258136426678cccce940e"},
+	}
+	if !reflect.DeepEqual(changed, expected) {
+		t.Fatalf("want %s, got %s", expected, changed)
+	}
+}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -582,3 +582,108 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPresubmitsForClusterProfiles(t *testing.T) {
+	makePresubmit := func(name string, agent pjapi.ProwJobAgent, profiles []string) prowconfig.Presubmit {
+		ret := prowconfig.Presubmit{
+			JobBase: prowconfig.JobBase{
+				Name:  name,
+				Agent: string(agent),
+				Spec:  &v1.PodSpec{}},
+		}
+		for _, p := range profiles {
+			ret.Spec.Volumes = append(ret.Spec.Volumes, v1.Volume{
+				Name: "cluster-profile",
+				VolumeSource: v1.VolumeSource{
+					Projected: &v1.ProjectedVolumeSource{
+						Sources: []v1.VolumeProjection{{
+							ConfigMap: &v1.ConfigMapProjection{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "cluster-profile-" + p,
+								},
+							},
+						}},
+					},
+				},
+			})
+		}
+		return ret
+	}
+	logger := logrus.NewEntry(logrus.New())
+	for _, tc := range []struct {
+		id       string
+		cfg      *prowconfig.Config
+		profiles []config.ClusterProfile
+		expected []string
+	}{{
+		id:       "empty",
+		cfg:      &prowconfig.Config{},
+		profiles: []config.ClusterProfile{{Name: "test-profile"}},
+	}, {
+		id: "not a kubernetes job",
+		cfg: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						makePresubmit("not-a-kubernetes-job", pjapi.JenkinsAgent, []string{}),
+					},
+				},
+			},
+		},
+		profiles: []config.ClusterProfile{{Name: "test-profile"}},
+	}, {
+		id: "job doesn't use cluster profiles",
+		cfg: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						makePresubmit("no-cluster-profile", pjapi.KubernetesAgent, []string{}),
+					},
+				},
+			},
+		},
+		profiles: []config.ClusterProfile{{Name: "test-profile"}},
+	}, {
+		id: "job doesn't use the cluster profile",
+		cfg: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						makePresubmit("doesnt-use-cluster-profile", pjapi.KubernetesAgent, []string{"another-profile"}),
+					},
+				},
+			},
+		},
+		profiles: []config.ClusterProfile{{Name: "test-profile"}},
+	}, {
+		id: "multiple jobs, one uses cluster the profile",
+		cfg: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				Presubmits: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						makePresubmit("no-cluster-profile", pjapi.KubernetesAgent, []string{}),
+					},
+					"some/other-repo": {
+						makePresubmit("uses-cluster-profile", pjapi.KubernetesAgent, []string{"test-profile"}),
+						makePresubmit("uses-another-profile", pjapi.KubernetesAgent, []string{"another-profile"}),
+					},
+				},
+			},
+		},
+		profiles: []config.ClusterProfile{{Name: "test-profile"}},
+		expected: []string{"uses-cluster-profile"},
+	}} {
+		t.Run(tc.id, func(t *testing.T) {
+			ret := GetPresubmitsForClusterProfiles(tc.cfg, tc.profiles, logger)
+			var names []string
+			for _, jobs := range ret {
+				for _, j := range jobs {
+					names = append(names, j.Name)
+				}
+			}
+			if !reflect.DeepEqual(names, tc.expected) {
+				t.Fatalf("want %s, got %s", tc.expected, names)
+			}
+		})
+	}
+}

--- a/pkg/rehearse/metrics.go
+++ b/pkg/rehearse/metrics.go
@@ -21,9 +21,10 @@ type Metrics struct {
 	Repo string `json:"repo"`
 	Pr   int    `json:"pr"`
 
-	ChangedCiopConfigs []string `json:"changed_ciop_configs"`
-	ChangedPresubmits  []string `json:"changed_presubmits"`
-	ChangedTemplates   []string `json:"changed_templates"`
+	ChangedCiopConfigs     []string `json:"changed_ciop_configs"`
+	ChangedPresubmits      []string `json:"changed_presubmits"`
+	ChangedTemplates       []string `json:"changed_templates"`
+	ChangedClusterProfiles []string `json:"changed_cluster_profiles"`
 
 	// map a job name to a list of reasons why we want to rehearse it
 	Opportunities map[string][]string `json:"opportunities"`
@@ -57,6 +58,12 @@ func (m *Metrics) RecordChangedCiopConfigs(configs config.CompoundCiopConfig) {
 func (m *Metrics) RecordChangedTemplates(templates config.CiTemplates) {
 	for templateName := range templates {
 		m.ChangedTemplates = append(m.ChangedTemplates, templateName)
+	}
+}
+
+func (m *Metrics) RecordChangedClusterProfiles(ps []config.ClusterProfile) {
+	for _, p := range ps {
+		m.ChangedClusterProfiles = append(m.ChangedClusterProfiles, p.Name)
 	}
 }
 


### PR DESCRIPTION
- [x] Changes to cluster profiles are identified.
- [x] Jobs that use those profiles are chosen for rehearsal.
- [x] Integration test verifies the above (see note below).
- [x] `ConfigMap` manager is changed to also create cluster profiles.
- [x] Jobs are changed to use those `CM`s.
- [x] More thorough unit testing.

Follow-up:
- Integration tests with `--allow-volumes` (potentially fixed in https://github.com/openshift/ci-operator-prowgen/pull/122).
- ConfigMap create/update method ([comment](https://github.com/openshift/ci-operator-prowgen/pull/118/#discussion_r268263411), https://github.com/openshift/ci-operator-prowgen/pull/123).
- Load plugin config from Prow and use the updateconfig library to generate the CMs ([comment](https://github.com/openshift/ci-operator-prowgen/pull/118/#discussion_r268264133)).