### PR TITLE
Refactor config brancher to populate many releases

### DIFF
--- a/cmd/config-brancher/main_test.go
+++ b/cmd/config-brancher/main_test.go
@@ -15,15 +15,15 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 	var testCases = []struct {
 		name           string
 		currentRelease string
-		futureRelease  string
+		bumpRelease    string
+		futureReleases []string
 		input          config.DataWithInfo
-		mirror         bool
 		output         []config.DataWithInfo
 	}{
 		{
 			name:           "config that doesn't promote anywhere is ignored",
 			currentRelease: "current-release",
-			futureRelease:  "future-release",
+			futureReleases: []string{"current-release"},
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: nil,
@@ -37,7 +37,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 		{
 			name:           "config that doesn't promote to official streams is ignored",
 			currentRelease: "current-release",
-			futureRelease:  "future-release",
+			futureReleases: []string{"current-release"},
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
@@ -54,7 +54,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 		{
 			name:           "config that doesn't promote to release payload is ignored",
 			currentRelease: "current-release",
-			futureRelease:  "future-release",
+			futureReleases: []string{"current-release"},
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
@@ -71,7 +71,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 		{
 			name:           "config that promotes to the current release from master gets a branched config for the current release",
 			currentRelease: "current-release",
-			futureRelease:  "future-release",
+			futureReleases: []string{"current-release"},
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
@@ -95,6 +95,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						PromotionConfiguration: &api.PromotionConfiguration{
 							Name:      "current-release",
 							Namespace: "ocp",
+							Disabled:  true,
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -107,29 +108,35 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						Org: "org", Repo: "repo", Branch: "release-current-release",
 					},
 				},
-				{
-					Configuration: api.ReleaseBuildConfiguration{
-						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release",
-							Namespace: "ocp",
-						},
-						InputConfiguration: api.InputConfiguration{
-							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-								Name:      "future-release",
-								Namespace: "ocp",
-							},
-						},
-					},
-					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "master",
-					},
-				},
 			},
 		},
 		{
-			name:           "config that promotes to the current release from master gets a mirrored config for the current release",
+			name:           "config that promotes to the current release from an non-dev branch gets no new config for the current release",
 			currentRelease: "current-release",
-			futureRelease:  "future-release",
+			futureReleases: []string{"current-release"},
+			input: config.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					PromotionConfiguration: &api.PromotionConfiguration{
+						Name:      "current-release",
+						Namespace: "ocp",
+					},
+					InputConfiguration: api.InputConfiguration{
+						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Name:      "current-release",
+							Namespace: "ocp",
+						},
+					},
+				},
+				Info: config.Info{
+					Org: "org", Repo: "repo", Branch: "openshift-current-release",
+				},
+			},
+			output: []config.DataWithInfo{},
+		},
+		{
+			name:           "config that promotes to the current release from master gets a branched config for the every future release",
+			currentRelease: "current-release",
+			futureReleases: []string{"current-release", "future-release-1", "future-release-2"},
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
@@ -147,7 +154,6 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					Org: "org", Repo: "repo", Branch: "master",
 				},
 			},
-			mirror: true,
 			output: []config.DataWithInfo{
 				{
 					Configuration: api.ReleaseBuildConfiguration{
@@ -170,162 +176,44 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "current-release",
+							Name:      "future-release-1",
 							Namespace: "ocp",
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-								Name:      "current-release",
+								Name:      "future-release-1",
 								Namespace: "ocp",
 							},
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "master",
-					},
-				},
-			},
-		},
-		{
-			name:           "config that promotes to the current release from an openshift branch gets a branched config for the new release",
-			currentRelease: "current-release",
-			futureRelease:  "future-release",
-			input: config.DataWithInfo{
-				Configuration: api.ReleaseBuildConfiguration{
-					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "current-release",
-						Namespace: "ocp",
-					},
-					InputConfiguration: api.InputConfiguration{
-						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-							Name:      "current-release",
-							Namespace: "ocp",
-						},
-					},
-				},
-				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "openshift-current-release",
-				},
-			},
-			output: []config.DataWithInfo{
-				{
-					Configuration: api.ReleaseBuildConfiguration{
-						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "current-release",
-							Namespace: "ocp",
-						},
-						InputConfiguration: api.InputConfiguration{
-							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-								Name:      "current-release",
-								Namespace: "ocp",
-							},
-						},
-					},
-					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "openshift-current-release",
+						Org: "org", Repo: "repo", Branch: "release-future-release-1",
 					},
 				},
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release",
+							Name:      "future-release-2",
 							Namespace: "ocp",
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-								Name:      "future-release",
+								Name:      "future-release-2",
 								Namespace: "ocp",
 							},
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "openshift-future-release",
+						Org: "org", Repo: "repo", Branch: "release-future-release-2",
 					},
 				},
 			},
 		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			actual, expected := generateBranchedConfigs(testCase.currentRelease, testCase.futureRelease, testCase.input, testCase.mirror), testCase.output
-			if len(actual) != len(expected) {
-				t.Fatalf("%s: did not generate correct amount of output configs, needed %d got %d", testCase.name, len(expected), len(actual))
-			}
-			for i := range expected {
-				if !reflect.DeepEqual(actual[i].Info, expected[i].Info) {
-					t.Errorf("%s: got incorrect path elements: %v", testCase.name, diff.ObjectReflectDiff(actual[i].Info, expected[i].Info))
-				}
-				if !reflect.DeepEqual(actual[i].Configuration.PromotionConfiguration, expected[i].Configuration.PromotionConfiguration) {
-					t.Errorf("%s: got incorrect promotion config: %v", testCase.name, diff.ObjectReflectDiff(actual[i].Configuration.PromotionConfiguration, expected[i].Configuration.PromotionConfiguration))
-				}
-				if !reflect.DeepEqual(actual[i].Configuration.ReleaseTagConfiguration, expected[i].Configuration.ReleaseTagConfiguration) {
-					t.Errorf("%s: got incorrect release input config: %v", testCase.name, diff.ObjectReflectDiff(actual[i].Configuration.ReleaseTagConfiguration, expected[i].Configuration.ReleaseTagConfiguration))
-				}
-			}
-		})
-	}
-}
-
-func TestGenerateUnmirroredConfigs(t *testing.T) {
-	var testCases = []struct {
-		name           string
-		currentRelease string
-		futureRelease  string
-		input          config.DataWithInfo
-		output         []config.DataWithInfo
-	}{
 		{
-			name:           "config that doesn't promote anywhere is ignored",
+			name:           "previously branched config that promotes to the current release from master bumps to the future release and de-mirrors correctly",
 			currentRelease: "current-release",
-			futureRelease:  "future-release",
-			input: config.DataWithInfo{
-				Configuration: api.ReleaseBuildConfiguration{
-					PromotionConfiguration: nil,
-				},
-				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "branch",
-				},
-			},
-			output: nil,
-		},
-		{
-			name:           "config that doesn't promote to official streams is ignored",
-			currentRelease: "current-release",
-			futureRelease:  "future-release",
-			input: config.DataWithInfo{
-				Configuration: api.ReleaseBuildConfiguration{
-					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "custom",
-						Namespace: "custom",
-					},
-				},
-				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "branch",
-				},
-			},
-			output: nil,
-		},
-		{
-			name:           "config that doesn't promote to release payload is ignored",
-			currentRelease: "current-release",
-			futureRelease:  "future-release",
-			input: config.DataWithInfo{
-				Configuration: api.ReleaseBuildConfiguration{
-					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "4.123",
-						Namespace: "ocp",
-					},
-				},
-				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "branch",
-				},
-			},
-			output: nil,
-		},
-		{
-			name:           "config that promotes to the current release from master gets bumped for the current release",
-			currentRelease: "current-release",
-			futureRelease:  "future-release",
+			bumpRelease:    "future-release-1",
+			futureReleases: []string{"current-release", "future-release-1", "future-release-2"},
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
@@ -347,12 +235,12 @@ func TestGenerateUnmirroredConfigs(t *testing.T) {
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release",
+							Name:      "future-release-1",
 							Namespace: "ocp",
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-								Name:      "future-release",
+								Name:      "future-release-1",
 								Namespace: "ocp",
 							},
 						},
@@ -361,37 +249,11 @@ func TestGenerateUnmirroredConfigs(t *testing.T) {
 						Org: "org", Repo: "repo", Branch: "master",
 					},
 				},
-			},
-		},
-		{
-			name:           "config that has a disabled promotion to the current release gets enabled for the current release",
-			currentRelease: "current-release",
-			futureRelease:  "future-release",
-			input: config.DataWithInfo{
-				Configuration: api.ReleaseBuildConfiguration{
-					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "current-release",
-						Namespace: "ocp",
-						Disabled:  true,
-					},
-					InputConfiguration: api.InputConfiguration{
-						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-							Name:      "current-release",
-							Namespace: "ocp",
-						},
-					},
-				},
-				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "release-current-release",
-				},
-			},
-			output: []config.DataWithInfo{
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
 							Name:      "current-release",
 							Namespace: "ocp",
-							Disabled:  false,
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -404,24 +266,59 @@ func TestGenerateUnmirroredConfigs(t *testing.T) {
 						Org: "org", Repo: "repo", Branch: "release-current-release",
 					},
 				},
+				{
+					Configuration: api.ReleaseBuildConfiguration{
+						PromotionConfiguration: &api.PromotionConfiguration{
+							Name:      "future-release-1",
+							Namespace: "ocp",
+							Disabled:  true,
+						},
+						InputConfiguration: api.InputConfiguration{
+							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+								Name:      "future-release-1",
+								Namespace: "ocp",
+							},
+						},
+					},
+					Info: config.Info{
+						Org: "org", Repo: "repo", Branch: "release-future-release-1",
+					},
+				},
+				{
+					Configuration: api.ReleaseBuildConfiguration{
+						PromotionConfiguration: &api.PromotionConfiguration{
+							Name:      "future-release-2",
+							Namespace: "ocp",
+						},
+						InputConfiguration: api.InputConfiguration{
+							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+								Name:      "future-release-2",
+								Namespace: "ocp",
+							},
+						},
+					},
+					Info: config.Info{
+						Org: "org", Repo: "repo", Branch: "release-future-release-2",
+					},
+				},
 			},
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, expected := generateUnmirroredConfigs(testCase.currentRelease, testCase.futureRelease, testCase.input), testCase.output
+			actual, expected := generateBranchedConfigs(testCase.currentRelease, testCase.bumpRelease, testCase.futureReleases, testCase.input), testCase.output
 			if len(actual) != len(expected) {
 				t.Fatalf("%s: did not generate correct amount of output configs, needed %d got %d", testCase.name, len(expected), len(actual))
 			}
 			for i := range expected {
 				if !reflect.DeepEqual(actual[i].Info, expected[i].Info) {
-					t.Errorf("%s: got incorrect path elements: %v", testCase.name, diff.ObjectReflectDiff(actual[i].Info, expected[i].Info))
+					t.Errorf("%s: [%d] got incorrect path elements: %v", testCase.name, i, diff.ObjectReflectDiff(actual[i].Info, expected[i].Info))
 				}
 				if !reflect.DeepEqual(actual[i].Configuration.PromotionConfiguration, expected[i].Configuration.PromotionConfiguration) {
-					t.Errorf("%s: got incorrect promotion config: %v", testCase.name, diff.ObjectReflectDiff(actual[i].Configuration.PromotionConfiguration, expected[i].Configuration.PromotionConfiguration))
+					t.Errorf("%s: [%d] got incorrect promotion config: %v", testCase.name, i, diff.ObjectReflectDiff(actual[i].Configuration.PromotionConfiguration, expected[i].Configuration.PromotionConfiguration))
 				}
 				if !reflect.DeepEqual(actual[i].Configuration.ReleaseTagConfiguration, expected[i].Configuration.ReleaseTagConfiguration) {
-					t.Errorf("%s: got incorrect release input config: %v", testCase.name, diff.ObjectReflectDiff(actual[i].Configuration.ReleaseTagConfiguration, expected[i].Configuration.ReleaseTagConfiguration))
+					t.Errorf("%s: [%d] got incorrect release input config: %v", testCase.name, i, diff.ObjectReflectDiff(actual[i].Configuration.ReleaseTagConfiguration, expected[i].Configuration.ReleaseTagConfiguration))
 				}
 			}
 		})

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/sirupsen/logrus"
-
 	cioperatorapi "github.com/openshift/ci-operator/pkg/api"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/flagutil"
 )
 
 const (
@@ -21,16 +22,16 @@ const (
 // being promoted. This is a proxy for determining if a configuration contributes to
 // the release payload.
 func PromotesOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
-	return !isDisabled(configSpec) && BuildsOfficialImages(configSpec)
+	return !isDisabled(configSpec) && buildOfficialImages(configSpec)
 }
 
 func isDisabled(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
 	return configSpec.PromotionConfiguration != nil && configSpec.PromotionConfiguration.Disabled
 }
 
-// BuildsOfficialImages determines if a configuration will result in official images
+// buildOfficialImages determines if a configuration will result in official images
 // being built.
-func BuildsOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
+func buildOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
 	promotionNamespace := extractPromotionNamespace(configSpec)
 	promotionName := extractPromotionName(configSpec)
 	return (promotionNamespace == okdPromotionNamespace && promotionName == okd40Imagestream) || promotionNamespace == ocpPromotionNamespace
@@ -52,32 +53,23 @@ func extractPromotionName(configSpec *cioperatorapi.ReleaseBuildConfiguration) s
 	return ""
 }
 
-// DetermineReleaseBranches determines the branch that will be used to continue promoting
-// to the current release as well as the branch that will promote to the future release,
+// DetermineReleaseBranch determines the branch that will be used to the future release,
 // based on the branch that is currently promoting to the current release.
-func DetermineReleaseBranches(currentRelease, futureRelease, currentBranch string) (string, string, error) {
-	// futureBranchForCurrentRelease is the branch that will promote to the current imagestream once we branch configs
-	var futureBranchForCurrentRelease string
-	// futureBranchForFutureRelease is the branch that will promote to the future imagestream once we branch configs
-	var futureBranchForFutureRelease string
+func DetermineReleaseBranch(currentRelease, futureRelease, currentBranch string) (string, error) {
 	if currentBranch == "master" {
-		futureBranchForCurrentRelease = fmt.Sprintf("release-%s", currentRelease)
-		futureBranchForFutureRelease = currentBranch
+		return fmt.Sprintf("release-%s", futureRelease), nil
 	} else if currentBranch == fmt.Sprintf("openshift-%s", currentRelease) {
-		futureBranchForCurrentRelease = currentBranch
-		futureBranchForFutureRelease = fmt.Sprintf("openshift-%s", futureRelease)
+		return fmt.Sprintf("openshift-%s", futureRelease), nil
 	} else {
-		return "", "", fmt.Errorf("invalid branch %q promoting to current release", currentBranch)
+		return "", fmt.Errorf("invalid branch %q promoting to current release", currentBranch)
 	}
-	return futureBranchForCurrentRelease, futureBranchForFutureRelease, nil
 }
 
 type Options struct {
 	ConfigDir      string
 	CurrentRelease string
-	FutureRelease  string
-	Mirror         bool
-	Unmirror       bool
+	FutureReleases flagutil.Strings
+	BumpRelease    string
 	Confirm        bool
 	Org            string
 	Repo           string
@@ -94,9 +86,22 @@ func (o *Options) Validate() error {
 		return errors.New("required flag --current-release was unset")
 	}
 
-	if o.FutureRelease == "" {
-		return errors.New("required flag --future-release was unset")
+	if len(o.FutureReleases.Strings()) == 0 {
+		return errors.New("required flag --future-release was not provided at least once")
 	}
+
+	// we always want to make sure that we are updating the config for the release
+	// branch that tracks the current release, but we don't need the user to provide
+	// the value twice in flags
+	if err := o.FutureReleases.Set(o.CurrentRelease); err != nil {
+		return fmt.Errorf("could not add current release to future releases: %v", err)
+	}
+
+	futureReleases := sets.NewString(o.FutureReleases.Strings()...)
+	if o.BumpRelease != "" && !futureReleases.Has(o.BumpRelease) {
+		return fmt.Errorf("future releases %v do not contain bump release %v", futureReleases.List(), o.BumpRelease)
+	}
+
 	level, err := logrus.ParseLevel(o.logLevel)
 	if err != nil {
 		return fmt.Errorf("invalid --log-level: %v", err)
@@ -108,8 +113,8 @@ func (o *Options) Validate() error {
 func (o *Options) Bind(fs *flag.FlagSet) {
 	fs.StringVar(&o.ConfigDir, "config-dir", "", "Path to CI Operator configuration directory.")
 	fs.StringVar(&o.CurrentRelease, "current-release", "", "Configurations targeting this release will get branched.")
-	fs.StringVar(&o.FutureRelease, "future-release", "", "Configurations will get branched to target this release.")
-	fs.BoolVar(&o.Mirror, "mirror", false, "Mirror the promotion config, but disable it in the target.")
+	fs.Var(&o.FutureReleases, "future-release", "Configurations will get branched to target this release, provide one or more times.")
+	fs.StringVar(&o.BumpRelease, "bump-release", "", "Bump the dev config to this release and manage mirroring.")
 	fs.BoolVar(&o.Confirm, "confirm", false, "Create the branched configuration files.")
 	fs.StringVar(&o.logLevel, "log-level", "info", "Level at which to log output.")
 	fs.StringVar(&o.Org, "org", "", "Limit repos affected to those in this org.")

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -72,54 +72,48 @@ func TestPromotesOfficialImages(t *testing.T) {
 
 func TestDetermineReleaseBranches(t *testing.T) {
 	var testCases = []struct {
-		name                                                                        string
-		currentRelease, futureRelease, currentBranch                                string
-		expectedFutureBranchForCurrentRelease, expectedFutureBranchForFutureRelease string
-		expectedError                                                               bool
+		name                                         string
+		currentRelease, futureRelease, currentBranch string
+		expectedFutureBranch                         string
+		expectedError                                bool
 	}{
 		{
-			name:                                  "promotion from weird branch errors",
-			currentRelease:                        "4.0",
-			futureRelease:                         "4.1",
-			currentBranch:                         "weird",
-			expectedFutureBranchForCurrentRelease: "",
-			expectedFutureBranchForFutureRelease:  "",
-			expectedError:                         true,
+			name:                 "promotion from weird branch errors",
+			currentRelease:       "4.0",
+			futureRelease:        "4.1",
+			currentBranch:        "weird",
+			expectedFutureBranch: "",
+			expectedError:        true,
 		},
 		{
-			name:                                  "promotion from master makes a release branch",
-			currentRelease:                        "4.0",
-			futureRelease:                         "4.1",
-			currentBranch:                         "master",
-			expectedFutureBranchForCurrentRelease: "release-4.0",
-			expectedFutureBranchForFutureRelease:  "master",
-			expectedError:                         false,
+			name:                 "promotion from master makes a release branch",
+			currentRelease:       "4.0",
+			futureRelease:        "4.1",
+			currentBranch:        "master",
+			expectedFutureBranch: "release-4.1",
+			expectedError:        false,
 		},
 		{
-			name:                                  "promotion from openshift release branch makes a new release branch",
-			currentRelease:                        "4.0",
-			futureRelease:                         "4.1",
-			currentBranch:                         "openshift-4.0",
-			expectedFutureBranchForCurrentRelease: "openshift-4.0",
-			expectedFutureBranchForFutureRelease:  "openshift-4.1",
-			expectedError:                         false,
+			name:                 "promotion from openshift release branch makes a new release branch",
+			currentRelease:       "4.0",
+			futureRelease:        "4.1",
+			currentBranch:        "openshift-4.0",
+			expectedFutureBranch: "openshift-4.1",
+			expectedError:        false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actualFutureBranchForCurrentRelease, actualFutureBranchForFutureRelease, err := DetermineReleaseBranches(testCase.currentRelease, testCase.futureRelease, testCase.currentBranch)
+			actualFutureBranch, err := DetermineReleaseBranch(testCase.currentRelease, testCase.futureRelease, testCase.currentBranch)
 			if err == nil && testCase.expectedError {
 				t.Errorf("%s: expected an error, but got none", testCase.name)
 			}
 			if err != nil && !testCase.expectedError {
 				t.Errorf("%s: expected no error, but got one: %v", testCase.name, err)
 			}
-			if actual, expected := actualFutureBranchForCurrentRelease, testCase.expectedFutureBranchForCurrentRelease; actual != expected {
-				t.Errorf("%s: incorrect future branch to promote to current release, expected %q, got %q", testCase.name, expected, actual)
-			}
-			if actual, expected := actualFutureBranchForFutureRelease, testCase.expectedFutureBranchForFutureRelease; actual != expected {
-				t.Errorf("%s: incorrect future branch to promote to future release, expected %q, got %q", testCase.name, expected, actual)
+			if actual, expected := actualFutureBranch, testCase.expectedFutureBranch; actual != expected {
+				t.Errorf("%s: incorrect future branch, expected %q, got %q", testCase.name, expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
The config-brancher tool has been refactored to support the new paradigm
for branches. This tool is intended to make the process of branching and
duplicating configuration for the CI Operator easy across many
repositories.

We select a set of repositories to operate on by looking at which are
actively promoting images into a specific OpenShift release, provided by
`--current-release`. Branches of repos that actively promote to this
release are considered to be our dev branches.

Once we've chosen a set of configurations to operate on, we can do one
of two actions:
 - mirror configuration out, copying the development branch config to
   all branches for the provided `--future-release` values, not changing
   the configuration for the dev branch and making sure that the release
   branch for the version that matches that in the dev branch has a
   disabled promotion stanza to ensure only one branch feeds a release
   ImageStream
 - bump configuration files, moving the development branch to promote to
   the version in the `--bump` flag, enabling the promotion in the
   release branch that used to match the dev branch version and
   disabling promotion in the release branch that now matches the dev
   branch version.

This will support the workflow where we have a dev branch coexisting
with many release branches, one of which mirrors the dev branch
promotion configured in a disabled way.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 
/cc @openshift/developer-productivity-test-platform 