### PR TITLE
Always put periodics in the misc job config for sanity

### DIFF
--- a/cmd/config-shard-validator/main.go
+++ b/cmd/config-shard-validator/main.go
@@ -130,7 +130,7 @@ func main() {
 			}
 			if matches {
 				if updateConfig.Name != pathToCheck.configMap {
-					globLogger.Error("File matches glob from unexpected ConfigMap.")
+					globLogger.Errorf("File matches glob from unexpected ConfigMap %s instead of %s.", updateConfig.Name, pathToCheck.configMap)
 					foundFailures = true
 				}
 				matchesAny = true

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -46,6 +46,10 @@ func (i *Info) Basename() string {
 
 // ConfigMapName returns the configmap in which we expect this file to be uploaded
 func (i *Info) ConfigMapName() string {
+	// put periodics in the misc job since they are not directly correlated to code
+	if i.Type == "periodics" {
+		return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(""))
+	}
 	return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(i.Branch))
 }
 


### PR DESCRIPTION
Periodics may reference multiple branches or be used by external tools.