### PR TITLE
DPTP-339: Analyze metrics to compute how often rehearsals hit job limits

### DIFF
--- a/cmd/pj-rehearse-metrics/pj-rehearse-metrics.go
+++ b/cmd/pj-rehearse-metrics/pj-rehearse-metrics.go
@@ -142,19 +142,19 @@ func gatherOptions() options {
 	return o
 }
 
-func main() {
+func run() error {
 	o := gatherOptions()
 
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to create client")
+		return fmt.Errorf("failed to create client: %v", err)
 	}
 
 	if o.cacheDir == "" {
 		o.cacheDir, err = ioutil.TempDir("", "")
 		if err != nil {
-			logrus.WithError(err).Fatal("Failed to create a temporary directory")
+			return fmt.Errorf("failed to create a temporary directory: %v", err)
 		}
 		defer func() {
 			if err := os.RemoveAll(o.cacheDir); err != nil {
@@ -232,4 +232,12 @@ func main() {
 	}
 
 	fmt.Printf("\n")
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		logrus.WithError(err).Fatal("Failed to compute rehearsal metrics")
+	}
 }

--- a/pkg/rehearse/metrics.go
+++ b/pkg/rehearse/metrics.go
@@ -110,3 +110,17 @@ func (m *Metrics) Dump() {
 		}
 	}
 }
+
+func LoadMetrics(path string) (*Metrics, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := Metrics{}
+	if err = json.Unmarshal(data, &metrics); err != nil {
+		return nil, err
+	}
+
+	return &metrics, nil
+}

--- a/pkg/rehearse/metrics.go
+++ b/pkg/rehearse/metrics.go
@@ -2,9 +2,13 @@ package rehearse
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 
@@ -122,5 +126,76 @@ func LoadMetrics(path string) (*Metrics, error) {
 		return nil, err
 	}
 
+	if metrics.JobSpec == nil {
+		// old metrics artifact: partially reconstruct refs from the info we saved at the time
+		metrics.JobSpec = &downwardapi.JobSpec{
+			Refs: &v1.Refs{Org: metrics.Org, Repo: metrics.Repo, Pulls: []v1.Pull{{Number: metrics.Pr}}},
+		}
+	}
+
 	return &metrics, nil
+}
+
+type MetricsCounter interface {
+	Process(metrics *Metrics)
+	Report() string
+}
+
+type metricsCounter struct {
+	purpose        string
+	filter         func(metrics *Metrics) bool
+	seenPrs        sets.Int
+	totalBuilds    int
+	matchingBuilds int
+	matching       map[int][]*Metrics
+}
+
+func NewMetricsCounter(purpose string, filter func(metrics *Metrics) bool) MetricsCounter {
+	return &metricsCounter{
+		purpose:        purpose,
+		filter:         filter,
+		seenPrs:        sets.NewInt(),
+		totalBuilds:    0,
+		matchingBuilds: 0,
+		matching:       map[int][]*Metrics{},
+	}
+}
+
+func (m *metricsCounter) Process(metrics *Metrics) {
+	m.totalBuilds++
+	pr := metrics.JobSpec.Refs.Pulls[0].Number
+	m.seenPrs.Insert(pr)
+	if m.filter(metrics) {
+		m.matchingBuilds++
+		if m.matching[pr] == nil {
+			m.matching[pr] = []*Metrics{metrics}
+		} else {
+			m.matching[pr] = append(m.matching[pr], metrics)
+		}
+	}
+}
+
+func (m *metricsCounter) Report() string {
+	template := `# %s
+
+PR statistics:    %d/%d (%.f%%)
+Build statistics: %d/%d (%.f%%)
+
+PR links:
+%s
+`
+	prCount := len(m.matching)
+	links := []string{}
+	for pr, runs := range m.matching {
+		runNumbers := []string{}
+		for _, run := range runs {
+			runNumbers = append(runNumbers, run.JobSpec.BuildID)
+		}
+		line := fmt.Sprintf("- https://github.com/openshift/release/pull/%d (runs: %s)", pr, strings.Join(runNumbers, ","))
+		links = append(links, line)
+	}
+
+	pctPrs := float64(prCount) / float64(len(m.seenPrs)) * 100.0
+	pctBuilds := float64(m.matchingBuilds) / float64(m.totalBuilds) * 100.0
+	return fmt.Sprintf(template, m.purpose, prCount, len(m.seenPrs), pctPrs, m.matchingBuilds, m.totalBuilds, pctBuilds, strings.Join(links, "\n"))
 }

--- a/pkg/rehearse/metrics.go
+++ b/pkg/rehearse/metrics.go
@@ -191,7 +191,7 @@ PR links:
 		for _, run := range runs {
 			runNumbers = append(runNumbers, run.JobSpec.BuildID)
 		}
-		line := fmt.Sprintf("- https://github.com/openshift/release/pull/%d (runs: %s)", pr, strings.Join(runNumbers, ","))
+		line := fmt.Sprintf("- https://github.com/openshift/release/pull/%d (runs: %s)", pr, strings.Join(runNumbers, ", "))
 		links = append(links, line)
 	}
 


### PR DESCRIPTION
Very slightly future-proofed for the situation where we would need to track more interesting cases.

Example output:
```
$ pj-rehearse-metrics 
Scraped PR pr-logs/pull/openshift_release/3305/ (processed 2263 PRs)
# PRs hitting the limit of rehearsed jobs

PR statistics:    10/296 (3%)
Build statistics: 17/687 (2%)

PR links:
- https://github.com/openshift/release/pull/3315 (runs: 1580)
- https://github.com/openshift/release/pull/3401 (runs: 1799,1804,1822)
- https://github.com/openshift/release/pull/3419 (runs: 1844)
- https://github.com/openshift/release/pull/3442 (runs: 1921)
- https://github.com/openshift/release/pull/3251 (runs: 1384)
- https://github.com/openshift/release/pull/3321 (runs: 1572)
- https://github.com/openshift/release/pull/3323 (runs: 1576)
- https://github.com/openshift/release/pull/3343 (runs: 1646)
- https://github.com/openshift/release/pull/3383 (runs: 1739,1740,1770,1815,1896,1973)
- https://github.com/openshift/release/pull/3413 (runs: 1835)

```

/cc @stevekuznetsov @droslean @bbguimaraes 