### PR TITLE
Store full JobSpec in the metrics

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -132,10 +132,9 @@ func rehearseMain() int {
 			return gracefulExit(o.noFail, misconfigurationOutput)
 		}
 	}
+	metrics.JobSpec = jobSpec
 
 	prFields := logrus.Fields{prowgithub.OrgLogField: jobSpec.Refs.Org, prowgithub.RepoLogField: jobSpec.Refs.Repo}
-	metrics.Org = jobSpec.Refs.Org
-	metrics.Repo = jobSpec.Refs.Repo
 	logger := logrus.WithFields(prFields)
 
 	if jobSpec.Type != pjapi.PresubmitJob {
@@ -149,7 +148,7 @@ func rehearseMain() int {
 	if o.local {
 		prNumber = int(time.Now().Unix())
 	}
-	metrics.Pr = prNumber
+
 	logger = logrus.WithField(prowgithub.PrLogField, prNumber)
 	logger.Info("Rehearsing Prow jobs for a configuration PR")
 

--- a/pkg/rehearse/metrics.go
+++ b/pkg/rehearse/metrics.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 
 	"github.com/openshift/ci-operator-prowgen/pkg/config"
 )
@@ -17,9 +18,7 @@ type ExecutionMetrics struct {
 }
 
 type Metrics struct {
-	Org  string `json:"org"`
-	Repo string `json:"repo"`
-	Pr   int    `json:"pr"`
+	JobSpec *downwardapi.JobSpec `json:"spec"`
 
 	ChangedCiopConfigs     []string `json:"changed_ciop_configs"`
 	ChangedPresubmits      []string `json:"changed_presubmits"`
@@ -34,6 +33,11 @@ type Metrics struct {
 
 	logger logrus.Entry
 	file   string
+
+	// DEPRECATED (we need to keep these to read old artifacts)
+	Org  string `json:"org"`
+	Repo string `json:"repo"`
+	Pr   int    `json:"pr"`
 }
 
 func NewMetrics(file string) *Metrics {


### PR DESCRIPTION
/cc @stevekuznetsov @droslean @bbguimaraes 

In https://github.com/openshift/ci-operator-prowgen/pull/142 and a followup work, I found myself needing more information from the `JobSpec` and I realized it's probably more helpful to just save it all instead of extracting half of it and putting it into the metrics structure.

We have cca 300 old artfacts using old struct laying around, but first code that actually reads metrics is https://github.com/openshift/ci-operator-prowgen/pull/142 and I can deal with reading legacy artifacts there.