### PR TITLE
add vsphere cluster type

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -236,7 +236,7 @@ func AddRandomJobsForChangedTemplates(templates config.CiTemplates, prConfigPres
 	rehearsals := make(config.Presubmits)
 
 	for templateFile := range templates {
-		for _, clusterType := range []string{"aws", "gcs", "openstack", "libvirt"} {
+		for _, clusterType := range []string{"aws", "gcs", "openstack", "libvirt", "vsphere"} {
 			if repo, job := pickTemplateJob(prConfigPresubmits, templateFile, clusterType); job != nil {
 				jobLogger := loggers.Job.WithFields(logrus.Fields{"target-repo": repo, "target-job": job.Name})
 				jobLogger.Info("Picking job to rehearse the template changes")


### PR DESCRIPTION
Add `vsphere` cluster type when picking new jobs to rehearse a single template change.