### PR TITLE
Update references to input images on bump

### DIFF
--- a/cmd/config-brancher/main_test.go
+++ b/cmd/config-brancher/main_test.go
@@ -83,6 +83,27 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 							Name:      "current-release",
 							Namespace: "ocp",
 						},
+						BaseImages: map[string]api.ImageStreamTagReference{
+							"first": {
+								Name:      "current-release",
+								Namespace: "ocp",
+								Tag:       "first",
+							},
+						},
+						BaseRPMImages: map[string]api.ImageStreamTagReference{
+							"second": {
+								Name:      "current-release",
+								Namespace: "ocp",
+								Tag:       "second",
+							},
+						},
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Name:      "current-release",
+								Namespace: "ocp",
+								Tag:       "third",
+							},
+						},
 					},
 				},
 				Info: config.Info{
@@ -101,6 +122,27 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
 								Name:      "current-release",
 								Namespace: "ocp",
+							},
+							BaseImages: map[string]api.ImageStreamTagReference{
+								"first": {
+									Name:      "current-release",
+									Namespace: "ocp",
+									Tag:       "first",
+								},
+							},
+							BaseRPMImages: map[string]api.ImageStreamTagReference{
+								"second": {
+									Name:      "current-release",
+									Namespace: "ocp",
+									Tag:       "second",
+								},
+							},
+							BuildRootImage: &api.BuildRootImageConfiguration{
+								ImageStreamTagReference: &api.ImageStreamTagReference{
+									Name:      "current-release",
+									Namespace: "ocp",
+									Tag:       "third",
+								},
 							},
 						},
 					},
@@ -148,6 +190,27 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 							Name:      "current-release",
 							Namespace: "ocp",
 						},
+						BaseImages: map[string]api.ImageStreamTagReference{
+							"first": {
+								Name:      "current-release",
+								Namespace: "ocp",
+								Tag:       "first",
+							},
+						},
+						BaseRPMImages: map[string]api.ImageStreamTagReference{
+							"second": {
+								Name:      "current-release",
+								Namespace: "ocp",
+								Tag:       "second",
+							},
+						},
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Name:      "current-release",
+								Namespace: "ocp",
+								Tag:       "third",
+							},
+						},
 					},
 				},
 				Info: config.Info{
@@ -167,6 +230,27 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 								Name:      "current-release",
 								Namespace: "ocp",
 							},
+							BaseImages: map[string]api.ImageStreamTagReference{
+								"first": {
+									Name:      "current-release",
+									Namespace: "ocp",
+									Tag:       "first",
+								},
+							},
+							BaseRPMImages: map[string]api.ImageStreamTagReference{
+								"second": {
+									Name:      "current-release",
+									Namespace: "ocp",
+									Tag:       "second",
+								},
+							},
+							BuildRootImage: &api.BuildRootImageConfiguration{
+								ImageStreamTagReference: &api.ImageStreamTagReference{
+									Name:      "current-release",
+									Namespace: "ocp",
+									Tag:       "third",
+								},
+							},
 						},
 					},
 					Info: config.Info{
@@ -184,6 +268,27 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 								Name:      "future-release-1",
 								Namespace: "ocp",
 							},
+							BaseImages: map[string]api.ImageStreamTagReference{
+								"first": {
+									Name:      "future-release-1",
+									Namespace: "ocp",
+									Tag:       "first",
+								},
+							},
+							BaseRPMImages: map[string]api.ImageStreamTagReference{
+								"second": {
+									Name:      "future-release-1",
+									Namespace: "ocp",
+									Tag:       "second",
+								},
+							},
+							BuildRootImage: &api.BuildRootImageConfiguration{
+								ImageStreamTagReference: &api.ImageStreamTagReference{
+									Name:      "future-release-1",
+									Namespace: "ocp",
+									Tag:       "third",
+								},
+							},
 						},
 					},
 					Info: config.Info{
@@ -200,6 +305,27 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
 								Name:      "future-release-2",
 								Namespace: "ocp",
+							},
+							BaseImages: map[string]api.ImageStreamTagReference{
+								"first": {
+									Name:      "future-release-2",
+									Namespace: "ocp",
+									Tag:       "first",
+								},
+							},
+							BaseRPMImages: map[string]api.ImageStreamTagReference{
+								"second": {
+									Name:      "future-release-2",
+									Namespace: "ocp",
+									Tag:       "second",
+								},
+							},
+							BuildRootImage: &api.BuildRootImageConfiguration{
+								ImageStreamTagReference: &api.ImageStreamTagReference{
+									Name:      "future-release-2",
+									Namespace: "ocp",
+									Tag:       "third",
+								},
 							},
 						},
 					},

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -4,12 +4,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"regexp"
-
 	cioperatorapi "github.com/openshift/ci-operator/pkg/api"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/flagutil"
+	"regexp"
 )
 
 const (
@@ -34,7 +33,12 @@ func isDisabled(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
 func buildOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
 	promotionNamespace := extractPromotionNamespace(configSpec)
 	promotionName := extractPromotionName(configSpec)
-	return (promotionNamespace == okdPromotionNamespace && promotionName == okd40Imagestream) || promotionNamespace == ocpPromotionNamespace
+	return RefersToOfficialImage(promotionName, promotionNamespace)
+}
+
+// RefersToOfficialImage determines if an image is official
+func RefersToOfficialImage(name, namespace string) bool {
+	return (namespace == okdPromotionNamespace && name == okd40Imagestream) || namespace == ocpPromotionNamespace
 }
 
 func extractPromotionNamespace(configSpec *cioperatorapi.ReleaseBuildConfiguration) string {
@@ -51,6 +55,11 @@ func extractPromotionName(configSpec *cioperatorapi.ReleaseBuildConfiguration) s
 	}
 
 	return ""
+}
+
+// IsBumpable determines if the dev branch should be bumped or not
+func IsBumpable(branch, currentRelease string) bool {
+	return branch != fmt.Sprintf("openshift-%s", currentRelease)
 }
 
 // DetermineReleaseBranch determines the branch that will be used to the future release,


### PR DESCRIPTION
When we change the tag specificatio and promotion we also need to chase
those references throughout the config for any other inputs that users
have set.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 
/cc @openshift/openshift-team-developer-productivity-platform 