### PR TITLE
Revert "rehearse: use updateconfig for template CMs"

### DIFF
--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -24,9 +24,7 @@ import (
 	prowplugins "k8s.io/test-infra/prow/plugins"
 )
 
-const testRepoPath = "../../test/pj-rehearse-integration/master"
-
-var templatesPath = filepath.Join(testRepoPath, "/ci-operator/templates")
+const templatesPath = "../../test/pj-rehearse-integration/master/ci-operator/templates"
 
 func TestGetTemplates(t *testing.T) {
 	expectCiTemplates := getBaseCiTemplates(t)
@@ -40,14 +38,6 @@ func TestGetTemplates(t *testing.T) {
 func TestCreateCleanupCMTemplates(t *testing.T) {
 	ns := "test-namespace"
 	ciTemplates := getBaseCiTemplates(t)
-	configUpdaterCfg := prowplugins.ConfigUpdater{
-		Maps: map[string]prowplugins.ConfigMapSpec{
-			"ci-operator/templates/test-template.yaml": {
-				Name:       "cluster-launch-test-template",
-				Namespaces: []string{ns},
-			},
-		},
-	}
 	createByRehearseReq, err := labels.NewRequirement(createByRehearse, selection.Equals, []string{"true"})
 	if err != nil {
 		t.Fatal(err)
@@ -76,7 +66,7 @@ func TestCreateCleanupCMTemplates(t *testing.T) {
 		return true, nil, nil
 	})
 	client := cs.CoreV1().ConfigMaps(ns)
-	cmManager := NewTemplateCMManager(client, configUpdaterCfg, 1234, testRepoPath, logrus.NewEntry(logrus.New()))
+	cmManager := NewTemplateCMManager(client, prowplugins.ConfigUpdater{}, 1234, "not_used", logrus.NewEntry(logrus.New()))
 	if err := cmManager.CreateCMTemplates(ciTemplates); err != nil {
 		t.Fatalf("CreateCMTemplates() returned error: %v", err)
 	}

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -66,6 +66,15 @@ func NewProwJobClient(clusterConfig *rest.Config, namespace string, dry bool) (p
 func NewCMClient(clusterConfig *rest.Config, namespace string, dry bool) (coreclientset.ConfigMapInterface, error) {
 	if dry {
 		c := fake.NewSimpleClientset()
+		c.PrependReactor("create", "configmaps", func(action coretesting.Action) (bool, runtime.Object, error) {
+			cm := action.(coretesting.CreateAction).GetObject().(*v1.ConfigMap)
+			y, err := yaml.Marshal([]*v1.ConfigMap{cm})
+			if err != nil {
+				return true, nil, fmt.Errorf("failed to convert ConfigMap to YAML: %v", err)
+			}
+			fmt.Print(string(y))
+			return false, nil, nil
+		})
 		c.PrependReactor("update", "configmaps", func(action coretesting.Action) (bool, runtime.Object, error) {
 			cm := action.(coretesting.UpdateAction).GetObject().(*v1.ConfigMap)
 			y, err := yaml.Marshal([]*v1.ConfigMap{cm})

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -130,7 +130,12 @@
       ci.openshift.org/rehearse-pull: "1234"
       created-by-pj-rehearse: "true"
     name: rehearse-hnq8xb9r-test-template
-    namespace: test-namespace
+- metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.org/rehearse-pull: "1234"
+      created-by-pj-rehearse: "true"
+    name: rehearse-cluster-profile-test-profile-47224
 - data:
     vars-origin.yaml: |
       vars-origin.yaml

--- a/test/pj-rehearse-integration/master/cluster/ci/config/prow/plugins.yaml
+++ b/test/pj-rehearse-integration/master/cluster/ci/config/prow/plugins.yaml
@@ -3,6 +3,3 @@ config_updater:
     cluster/test-deploy/test-profile/*.yaml:
       name: cluster-profile-test-profile
       namespace: test-namespace
-    ci-operator/templates/test-template.yaml:
-      name: cluster-launch-test-template
-      namespace: test-namespace


### PR DESCRIPTION
This reverts commit 6e092d39ecea2d63a71151bba3dd57316681d616.

Sub-directories in `ci-operator/templates` were not properly handled. We did not have tests for this, I will add them to ensure we don't regress again and then reintroduce these changes.