### PR TITLE
rehearse: use updateconfig for template CMs

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -228,7 +228,7 @@ func rehearseMain() int {
 		return gracefulExit(o.noFail, misconfigurationOutput)
 	}
 
-	cmManager := config.NewTemplateCMManager(cmClient, pluginConfig, prNumber, o.releaseRepoPath, logger)
+	cmManager := config.NewTemplateCMManager(namespace, cmClient, pluginConfig, prNumber, o.releaseRepoPath, logger)
 	defer func() {
 		if err := cmManager.CleanupCMTemplates(); err != nil {
 			logger.WithError(err).Error("failed to clean up temporary template CM")

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -24,6 +24,8 @@ const (
 	CiopConfigInRepoPath = "ci-operator/config"
 	// TemplatesPath is the path of the templates from release repo
 	TemplatesPath = "ci-operator/templates"
+	// TemplatePrefix is the prefix added to ConfigMap names
+	TemplatePrefix = "prow-job-"
 	// ClusterProfilesPath is where profiles are stored in the release repo
 	ClusterProfilesPath = "cluster/test-deploy"
 	// ClusterProfilePrefix is the prefix added to ConfigMap names
@@ -96,10 +98,7 @@ func NewLocalJobSpec(path string) (*pjdwapi.JobSpec, error) {
 func GetAllConfigs(releaseRepoPath string, logger *logrus.Entry) *ReleaseRepoConfig {
 	config := &ReleaseRepoConfig{}
 	var err error
-
-	templatePath := filepath.Join(releaseRepoPath, TemplatesPath)
-	config.Templates, err = getTemplates(templatePath)
-	if err != nil {
+	if config.Templates, err = getTemplates(releaseRepoPath); err != nil {
 		logger.WithError(err).Warn("failed to load templates from release repo")
 	}
 

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -66,7 +66,7 @@ func TestCreateCleanupCMTemplates(t *testing.T) {
 		return true, nil, nil
 	})
 	client := cs.CoreV1().ConfigMaps(ns)
-	cmManager := NewTemplateCMManager(client, prowplugins.ConfigUpdater{}, 1234, "not_used", logrus.NewEntry(logrus.New()))
+	cmManager := NewTemplateCMManager(ns, client, prowplugins.ConfigUpdater{}, 1234, "not_used", logrus.NewEntry(logrus.New()))
 	if err := cmManager.CreateCMTemplates(ciTemplates); err != nil {
 		t.Fatalf("CreateCMTemplates() returned error: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestCreateClusterProfiles(t *testing.T) {
 	}
 	cs := fake.NewSimpleClientset()
 	client := cs.CoreV1().ConfigMaps(ns)
-	m := NewTemplateCMManager(client, configUpdaterCfg, pr, dir, logrus.NewEntry(logrus.New()))
+	m := NewTemplateCMManager(ns, client, configUpdaterCfg, pr, dir, logrus.NewEntry(logrus.New()))
 	if err := m.CreateClusterProfiles(profiles); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -833,10 +833,10 @@ func makeBasePresubmit() *prowconfig.Presubmit {
 func TestReplaceCMTemplateName(t *testing.T) {
 	const tempCMName = "rehearse-i0k3r9fp-test-template"
 
-	templates := config.CiTemplates{
-		"test-template.yaml":  []byte("test-template's content"),
-		"test-template2.yaml": []byte("test-template2's content"),
-		"test-template3.yaml": []byte("test-template3's content"),
+	templates := map[string]string{
+		"test-template.yaml":  tempCMName,
+		"test-template2.yaml": "template2",
+		"test-template3.yaml": "template3",
 	}
 
 	testCases := []struct {

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -129,13 +129,8 @@
     labels:
       ci.openshift.org/rehearse-pull: "1234"
       created-by-pj-rehearse: "true"
-    name: rehearse-hnq8xb9r-test-template
-- metadata:
-    creationTimestamp: null
-    labels:
-      ci.openshift.org/rehearse-pull: "1234"
-      created-by-pj-rehearse: "true"
-    name: rehearse-cluster-profile-test-profile-47224c86
+    name: rehearse-bb2jjv7j-test-template
+    namespace: test-namespace
 - data:
     vars-origin.yaml: |
       vars-origin.yaml
@@ -328,7 +323,7 @@
           - configMap:
               name: rehearse-cluster-profile-test-profile-47224c86
       - configMap:
-          name: rehearse-hnq8xb9r-test-template
+          name: rehearse-bb2jjv7j-test-template
         name: job-definition
     refs:
       base_ref: master
@@ -766,7 +761,7 @@
           - secret:
               name: cluster-secrets-aws
       - configMap:
-          name: rehearse-hnq8xb9r-test-template
+          name: rehearse-bb2jjv7j-test-template
         name: job-definition
     refs:
       base_ref: master
@@ -887,7 +882,7 @@
           - secret:
               name: cluster-secrets-openstack
       - configMap:
-          name: rehearse-hnq8xb9r-test-template
+          name: rehearse-bb2jjv7j-test-template
         name: job-definition
     refs:
       base_ref: master

--- a/test/pj-rehearse-integration/master/cluster/ci/config/prow/plugins.yaml
+++ b/test/pj-rehearse-integration/master/cluster/ci/config/prow/plugins.yaml
@@ -3,3 +3,6 @@ config_updater:
     cluster/test-deploy/test-profile/*.yaml:
       name: cluster-profile-test-profile
       namespace: test-namespace
+    ci-operator/templates/subdir/test-template.yaml:
+      name: prow-job-test-template
+      namespace: test-namespace


### PR DESCRIPTION
Take two.

94666d37 is new. I am not sure if it is strictly necessary because our `ConfigMap` client is namespace-scoped, but logs can be confusing in some cases without it.