### PR TITLE
Scaleup job no longer needs release RPMs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -135,7 +135,6 @@ func generatePodSpecTemplate(info *config.Info, release string, test *cioperator
 	} else if conf := test.OpenshiftAnsible40ClusterTestConfiguration; conf != nil {
 		template = "cluster-scaleup-e2e-40"
 		clusterProfile = conf.ClusterProfile
-		needsReleaseRpms = true
 	} else if conf := test.OpenshiftInstallerClusterTestConfiguration; conf != nil {
 		if !conf.Upgrade {
 			template = "cluster-launch-installer-e2e"


### PR DESCRIPTION
Repo path would be constructed automatically via ansible vars.

See https://github.com/openshift/release/pull/3759