### PR TITLE
Set RPM_REPO_CRIO_DIR for 4.x scaleup tasks

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -252,6 +252,14 @@ func generatePodSpecTemplate(info *config.Info, release string, test *cioperator
 			Value: repoPath,
 		})
 	}
+	if conf := test.OpenshiftAnsible40ClusterTestConfiguration; conf != nil {
+		container.Env = append(
+			container.Env,
+			kubeapi.EnvVar{
+				Name:  "RPM_REPO_CRIO_DIR",
+				Value: fmt.Sprintf("%s-rhel-7", release)},
+		)
+	}
 	if conf := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; conf != nil {
 		container.Env = append(
 			container.Env,


### PR DESCRIPTION
Set RPM_REPO_CRIO_DIR based on current release. crio RPMs are stored in different path dirs for 4.0 and 4.1 thus a simple map is required to pick the right one

Required for https://github.com/openshift/release/pull/3761