### PR TITLE
Update RPM_REPO_OPENSHIFT_ORIGIN url to be release-specific

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -243,13 +243,13 @@ func generatePodSpecTemplate(info *config.Info, release string, test *cioperator
 			kubeapi.EnvVar{Name: "TEST_COMMAND", Value: test.Commands})
 	}
 	if needsReleaseRpms && (info.Org != "openshift" || info.Repo != "origin") {
-		var repoPath = fmt.Sprintf("https://rpms.svc.ci.openshift.org/openshift-origin-v%s/", release)
-		if strings.HasPrefix(release, "origin-v") {
-			repoPath = fmt.Sprintf("https://rpms.svc.ci.openshift.org/openshift-%s/", release)
+		var dashedRelease = strings.Replace(release, ".", "-", -1)
+		if strings.HasPrefix(dashedRelease, "origin-v") {
+			dashedRelease = strings.Replace(dashedRelease, "origin-v", "", 1)
 		}
 		container.Env = append(container.Env, kubeapi.EnvVar{
 			Name:  "RPM_REPO_OPENSHIFT_ORIGIN",
-			Value: repoPath,
+			Value: fmt.Sprintf("https://artifacts-openshift-release-%s.svc.ci.openshift.org/repo/", dashedRelease),
 		})
 	}
 	if conf := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; conf != nil {

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -220,7 +220,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
-						{Name: "RPM_REPO_OPENSHIFT_ORIGIN", Value: "https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/"},
+						{Name: "RPM_REPO_OPENSHIFT_ORIGIN", Value: "https://artifacts-openshift-release-4-0.svc.ci.openshift.org/repo/"},
 					},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -34,7 +34,7 @@ presubmits:
         - name: JOB_NAME_SAFE
           value: e2e
         - name: RPM_REPO_OPENSHIFT_ORIGIN
-          value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+          value: https://artifacts-openshift-release-4-0.svc.ci.openshift.org/repo/
         - name: TEST_COMMAND
           value: make e2e
         image: ci-operator:latest


### PR DESCRIPTION
New routes are being used to serve version-specific rpms. This also adds more tests to ensure generated URL is correct