### PR TITLE
Use upstream default trigger regexes for jobs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -310,7 +310,7 @@ func generatePresubmitForTest(name string, info *config.Info, podSpec *kubeapi.P
 			Context: fmt.Sprintf("ci/prow/%s", name),
 		},
 		RerunCommand: fmt.Sprintf("/test %s", name),
-		Trigger:      fmt.Sprintf(`(?m)^/test (?:.*? )?%s(?: .*?)?$`, name),
+		Trigger:      prowconfig.DefaultTriggerFor(name),
 	}
 }
 

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -309,7 +309,7 @@ func generatePresubmitForTest(name string, info *config.Info, podSpec *kubeapi.P
 		Reporter: prowconfig.Reporter{
 			Context: fmt.Sprintf("ci/prow/%s", name),
 		},
-		RerunCommand: fmt.Sprintf("/test %s", name),
+		RerunCommand: prowconfig.DefaultRerunCommandFor(name),
 		Trigger:      prowconfig.DefaultTriggerFor(name),
 	}
 }

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -354,7 +354,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 				Context: "ci/prow/testname",
 			},
 			RerunCommand: "/test testname",
-			Trigger:      "(?m)^/test (?:.*? )?testname(?: .*?)?$",
+			Trigger:      `(?m)^/test( | .* )testname,?($|\s.*)`,
 		},
 	}}
 	for _, tc := range tests {
@@ -826,7 +826,7 @@ tests:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
@@ -869,7 +869,7 @@ tests:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
 `),
 		}, {
 			id:        "Using a variant config, one test and images, one existing job. Expect one presubmit, pre/post submit images jobs. Existing job should not be changed.",
@@ -988,7 +988,7 @@ tests:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?rhel-images(?: .*?)?$'
+    trigger: (?m)^/test( | .* )rhel-images,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
@@ -1032,7 +1032,7 @@ tests:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?rhel-unit(?: .*?)?$'
+    trigger: (?m)^/test( | .* )rhel-unit,?($|\s.*)
 `),
 			prowExpectedPostsubmitYAML: []byte(`postsubmits:
   super/duper:
@@ -1220,7 +1220,7 @@ tests:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
@@ -1263,7 +1263,7 @@ tests:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
 `),
 			prowExpectedPostsubmitYAML: []byte(`postsubmits:
   super/duper:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -67,7 +67,7 @@ presubmits:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?e2e(?: .*?)?$'
+    trigger: (?m)^/test( | .* )e2e,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -115,7 +115,7 @@ presubmits:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
   - agent: jenkins
     always_run: true
     branches:
@@ -168,7 +168,7 @@ presubmits:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?lint(?: .*?)?$'
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
@@ -211,7 +211,7 @@ presubmits:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)
   - agent: jenkins
     always_run: true
     context: ci/openshift-jenkins/oldschool

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
   - agent: jenkins
     always_run: true
     branches:
@@ -95,7 +95,7 @@ presubmits:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?lint(?: .*?)?$'
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
   - agent: kubernetes
     always_run: true
     branches:
@@ -138,4 +138,4 @@ presubmits:
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
-    trigger: '(?m)^/test (?:.*? )?unit(?: .*?)?$'
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION
Stop inventing our own trigger regexes for jobs, start using default
upstream ones. It looks like the upstream default regexes should:

1. Handle the CRLF newlines in bodies (our old `(?m)^/test (?:.*? )?%s(?: .*?)?$` didn't)
2. Accept comments more liberally, like `/test images, unit`