### PR TITLE
don't pickup template jobs that will be already rehearsed

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -273,7 +273,7 @@ func rehearseMain() int {
 	metrics.RecordOpportunity(presubmitsWithChangedCiopConfigs, "ci-operator-config-change")
 	toRehearse.AddAll(presubmitsWithChangedCiopConfigs)
 
-	presubmitsWithChangedTemplates := rehearse.AddRandomJobsForChangedTemplates(changedTemplates, prConfig.Prow.JobConfig.Presubmits, loggers, prNumber)
+	presubmitsWithChangedTemplates := rehearse.AddRandomJobsForChangedTemplates(changedTemplates, toRehearse, prConfig.Prow.JobConfig.Presubmits, loggers, prNumber)
 	metrics.RecordOpportunity(presubmitsWithChangedTemplates, "templates-change")
 	toRehearse.AddAll(presubmitsWithChangedTemplates)
 


### PR DESCRIPTION
In case of a changed template, the rehearse tool will pickup some jobs for each cluster type and template file. In that case we don't want to pick a new job with duplicated cluster type and template file with an already changed presubmit.